### PR TITLE
[mobile] fix docs page

### DIFF
--- a/src/components/GitGraph.tsx
+++ b/src/components/GitGraph.tsx
@@ -118,7 +118,7 @@ const GitGraph: React.SFC<GitGraphProps> = (p) => {
             }}>
             <svg xmlns="http://www.w3.org/2000/svg"
                  viewBox={`0 0 ${theWidth} ${g.maxHeight + 20}`}
-                 className="stargraph"
+                 className="hidden-md-down"
                  >
                 <g>
                     {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,8 +20,7 @@ const StyledHeader = styled.header`
     z-index: 2;
     position: fixed;
     width: 100%;
-    padding: 0;
-    padding-top: 5px;
+    padding: 5px 0;
     margin: 0;
   }
 `
@@ -38,9 +37,13 @@ const HeaderInner = styled(Container)`
 
 const MobileMenu = styled.div`
   margin-left: auto;
+  margin-right: -10px;
+  display: flex;
+  flex-direction: row;
+  align-items: start;
 
   > :not(:last-child) {
-    padding-right: 15px;
+    padding-right: 12px;
   }
 
   @media (min-width: ${getEmSize(breakpoints.md)}em) {
@@ -64,6 +67,8 @@ const Menu = styled.div`
     width: 100%;
     margin-top: 15px;
     flex-direction: column;
+    max-height: 85vh;
+    overflow: scroll;
 
     :before {
       content: '';
@@ -99,6 +104,15 @@ const Menu = styled.div`
   }
 `
 
+const HomepageLogo = styled.img`
+  width: 120px;
+
+  @media (max-width: ${getEmSize(breakpoints.md)}em) {
+    width: 100px;
+    margin-top: 3px;
+  }
+`
+
 const HomepageLink = styled(Link)`
   color: ${colors.fontColor1};
   font-size: ${dimensions.fontSize.menu};
@@ -115,30 +129,36 @@ interface HeaderProps {
     title: string
 }
 
-export default class Header extends React.Component<HeaderProps, {}> {
-    constructor(props: {}) {
+interface HeaderState {
+    isMenuOpen: boolean,
+}
+
+export default class Header extends React.Component<HeaderProps, HeaderState> {
+    constructor(props: HeaderProps) {
         super(props);
         this.state = {
-            isMenuOpen: false
+            isMenuOpen: false,
         }
         this.toggleMenu = this.toggleMenu.bind(this);
     }
 
     toggleMenu() {
         const { isMenuOpen } = this.state;
-        this.setState({ isMenuOpen: !isMenuOpen })
+        this.setState({ isMenuOpen: !isMenuOpen });
     }
 
     render() {
         const { isMenuOpen } = this.state;
         return <StyledHeader>
             <HeaderInner>
-                <HomepageLink to="/" style={{ paddingRight: 60 }}><img src={logo} style={{ width: 120 }} /></HomepageLink>
+                <HomepageLink to="/" style={{ paddingRight: 60, lineHeight: 'initial' }}>
+                    <HomepageLogo src={logo} />
+                </HomepageLink>
                 <MobileMenu>
                     {isMenuOpen ? null : <a href="https://gitpod.io/api/login">
-                        <button className='primary'>Log In</button>
+                        <button className='primary' style={{fontSize: '90%', padding: '6px 10px'}}>Log In</button>
                     </a>}
-                    <button onClick={this.toggleMenu} style={{border: 0}}>
+                    <button onClick={this.toggleMenu} style={{ border: 0, padding: '6px 10px' }}>
                         {isMenuOpen ? icons.cross() : icons.burger()}
                     </button>
                 </MobileMenu>
@@ -147,6 +167,8 @@ export default class Header extends React.Component<HeaderProps, {}> {
                     <HomepageLink to="/pricing">Pricing</HomepageLink>
                     <HomepageLink to="/docs">Docs</HomepageLink>
                     <HomepageLink to="/blog">Blog</HomepageLink>
+                    <HomepageLink className="hidden-md-up" to="/about">About</HomepageLink>
+                    <HomepageLink className="hidden-md-up" to="/contact">Contact</HomepageLink>
                     <a href="https://gitpod.io/api/login">
                         <button className='primary'>Log In</button>
                     </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ const StyledHeader = styled.header`
   background-color: ${colors.background1};
   color: ${transparentize(0.5, colors.fontColor1)};
 
-  @media (max-width: ${getEmSize(breakpoints.md)}em) {
+  @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
     z-index: 2;
     position: fixed;
     width: 100%;
@@ -62,7 +62,7 @@ const Menu = styled.div`
     margin-left: auto;
   }
 
-  @media (max-width: ${getEmSize(breakpoints.md)}em) {
+  @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
     height: auto;
     width: 100%;
     margin-top: 15px;
@@ -107,7 +107,7 @@ const Menu = styled.div`
 const HomepageLogo = styled.img`
   width: 120px;
 
-  @media (max-width: ${getEmSize(breakpoints.md)}em) {
+  @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
     width: 100px;
     margin-top: 3px;
   }

--- a/src/components/Logos.tsx
+++ b/src/components/Logos.tsx
@@ -11,7 +11,7 @@ const Logos: React.SFC<LogosProps> = ({ logos }) => (
     <>
         {logos.map(logoPlacement => {
             const [left, top, width] = logoPlacement;
-            return <img key={''+left+top+width} src={clean(greyLogo)} style={{
+            return <img key={''+left+top+width} src={clean(greyLogo)} className='hidden-md-down' style={{
                 position: 'absolute',
                 left,
                 top,

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -17,7 +17,7 @@ const BlogFeed = styled.div`
     flex-wrap: wrap;
     justify-content: space-between;
 
-    @media (max-width: ${getEmSize(breakpoints.md)}em) {
+    @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
         justify-content: space-around;
     }
 `
@@ -31,7 +31,7 @@ const BlogPost = styled.div`
     display: flex;
     flex-direction: column;
 
-    @media (max-width: ${getEmSize(breakpoints.sm)}em) {
+    @media (max-width: ${getEmSize(breakpoints.sm - 1)}em) {
         width: auto;
         min-width: 280px;
     }

--- a/src/resources/Arrow_down.svg
+++ b/src/resources/Arrow_down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="58.337" height="27.913" viewBox="0 0 58.337 27.913">
+  <path d="M0,56.995,25.822,28.5,0,0" transform="translate(57.666 0) rotate(90)" fill="none" stroke="#707070" stroke-width="2"/>
+</svg>

--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -1,5 +1,6 @@
 import { dimensions, fonts, colors, breakpoints } from './variables'
 import { getEmSize } from './mixins'
+import arrowDown from '../resources/Arrow_down.svg';
 
 export default `
   html {
@@ -15,6 +16,7 @@ export default `
   html {
     font-size: ${dimensions.fontSize.regular}px !important;
     line-height: ${dimensions.lineHeight.regular} !important;
+    overflow-x: hidden;
   }
 
   body {
@@ -116,7 +118,7 @@ export default `
     border-top: 1px solid ${colors.ui.light};
   }
 
-  button {
+  button, select {
     margin: 10px 0px;
     padding: 8px 14px;
     border-radius: 2px;
@@ -140,7 +142,15 @@ export default `
     }
   }
 
-
+  select {
+    appearance: none;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    border-radius: 25px;
+    width: 100%;
+    background: url('${arrowDown}') no-repeat 95% 55%;
+    background-size: 20px;
+  }
 
 
 
@@ -215,14 +225,20 @@ export default `
       font-size: 12px;
   }
 
-  .stargraph {
-      @media (max-width: ${getEmSize(breakpoints.md)}em) {
+  .draggable {
+      cursor: move;
+  }
+
+  .hidden-md-up {
+      @media (min-width: ${getEmSize(breakpoints.md)}em) {
           display: none;
       }
   }
 
-  .draggable {
-      cursor: move;
+  .hidden-md-down {
+      @media (max-width: ${getEmSize(breakpoints.md)}em) {
+          display: none;
+      }
   }
 
   .article {

--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -236,7 +236,7 @@ export default `
   }
 
   .hidden-md-down {
-      @media (max-width: ${getEmSize(breakpoints.md)}em) {
+      @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
           display: none;
       }
   }

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -14,7 +14,7 @@ import Logos from '../components/Logos';
 const DocContent = styled.div`
     display: flex;
 
-    @media (max-width: ${getEmSize(breakpoints.md)}em) {
+    @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
         flex-direction: column;
     }
 `
@@ -27,12 +27,12 @@ const DocSidebar = styled.div`
     border-color: ${colors.fontColor2};
     margin-right: 10px;
 
-    @media (max-width: ${getEmSize(breakpoints.md)}em) {
+    @media (max-width: ${getEmSize(breakpoints.md - 1)}em) {
       padding-top: 60px;
       width: auto;
     }
 
-    @media (min-width: ${getEmSize(breakpoints.sm)}em) and (max-width: ${getEmSize(breakpoints.md)}em) {
+    @media (min-width: ${getEmSize(breakpoints.sm)}em) and (max-width: ${getEmSize(breakpoints.md - 1)}em) {
       max-width: 80%;
       margin-left: 10%;
     }

--- a/src/templates/doc.tsx
+++ b/src/templates/doc.tsx
@@ -1,13 +1,42 @@
 import * as React from 'react'
-import { graphql } from 'gatsby'
+import styled from '@emotion/styled'
+import { graphql, navigate } from 'gatsby'
 
 import Page from '../components/Page'
 import Container from '../components/Container'
 import IndexLayout from '../layouts'
 import { MENU } from '../docs/menu';
 import { Link } from 'gatsby'
-import { colors } from '../styles/variables';
+import { colors, breakpoints } from '../styles/variables';
+import { getEmSize } from '../styles/mixins'
 import Logos from '../components/Logos';
+
+const DocContent = styled.div`
+    display: flex;
+
+    @media (max-width: ${getEmSize(breakpoints.md)}em) {
+        flex-direction: column;
+    }
+`
+
+const DocSidebar = styled.div`
+    width: 200px;
+    min-width: 200px;
+    padding-top: 120px;
+    border-radius: 3px;
+    border-color: ${colors.fontColor2};
+    margin-right: 10px;
+
+    @media (max-width: ${getEmSize(breakpoints.md)}em) {
+      padding-top: 60px;
+      width: auto;
+    }
+
+    @media (min-width: ${getEmSize(breakpoints.sm)}em) and (max-width: ${getEmSize(breakpoints.md)}em) {
+      max-width: 80%;
+      margin-left: 10%;
+    }
+`
 
 interface DocTemplateProps {
   data: {
@@ -41,15 +70,20 @@ const DocTemplate: React.SFC<DocTemplateProps> = ({ data }) => (
                     [-120, 630, 70],
                     [40, 830, 120]
                 ]} />
-        <div style={{ display: 'flex'}}>
-            <div style={{ width: 200, minWidth: 200, maxHeight: 550, paddingTop: 120, borderRadius: 3, borderColor: colors.fontColor2, marginRight: 10}}>
-                <DocMenu/>
-            </div>
+        <DocContent>
+            <DocSidebar>
+                <div className='hidden-md-down'>
+                    <DocMenu/>
+                </div>
+                <div className='hidden-md-up'>
+                    <DocTopicChooser/>
+                </div>
+            </DocSidebar>
             <div className="article">
                 <h4 style={{color: colors.fontColor2, marginBottom: 0, marginTop: 30}}>Docs</h4>
                 <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
             </div>
-        </div>
+        </DocContent>
       </Container>
     </Page>
   </IndexLayout>
@@ -102,3 +136,27 @@ const DocMenu: React.SFC<DocMenuProps> = () => {
         })}
     </div>
 }
+
+interface DocTopicChooserProps {
+}
+
+function onSelectTopic(event: React.FormEvent<HTMLSelectElement>) {
+    navigate(event.currentTarget.value);
+}
+
+export const DocTopicChooser: React.SFC<DocTopicChooserProps> = () => {
+    return <select className='secondary' onChange={onSelectTopic}>
+        <option value='#' selected={true}>Select A Topic</option>
+        {MENU.map(m => {
+            return <>
+                <option key={m.path} value={`/docs/${m.path}`}>{m.title}</option>
+                {
+                    (m.subMenu || []).map(m =>
+                        <option key={m.path} value={`/docs/${m.path}`}>&nbsp;&nbsp;&nbsp;&nbsp;{m.title}</option>
+                    )
+                }
+            </>
+        })}
+    </select>
+}
+


### PR DESCRIPTION
Expandable table of contents in mobile menu (I also include the ToC at the bottom of the mobile Docs page, for convenience):

<img width="837" alt="Screenshot 2019-03-19 at 16 53 04" src="https://user-images.githubusercontent.com/599268/54621350-e7a5cb00-4a67-11e9-8adb-f2b029b7c6dc.png">

---

Docs page on mobile (needs a bit more padding at the top, but otherwise quite readable):

<img width="410" alt="Screenshot 2019-03-19 at 16 54 10" src="https://user-images.githubusercontent.com/599268/54621443-0ad07a80-4a68-11e9-91e3-4402c991b17d.png">

---

Docs page on mobile in landscape mode (a bit more padding left and right -- iPad in portrait looks the same):

<img width="706" alt="Screenshot 2019-03-19 at 16 54 44" src="https://user-images.githubusercontent.com/599268/54621548-3489a180-4a68-11e9-8bee-8d0e5ad41b32.png">

---

iPad in landscape mode is able to show the full page (non-mobile version).