### PR TITLE
pricing terms

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -21,7 +21,7 @@ const Box: React.SFC<BoxProps> = (p) => (
         position: 'relative',
         ...p.style
     }}>
-        <h3 style={{position: 'absolute', top: -35, backgroundColor: colors.background1, padding: '0 15px'}}>{p.title}</h3>
+        <h3 style={{fontSize: 19, position: 'absolute', top: -35, backgroundColor: colors.background1, padding: '0 15px'}}>{p.title}</h3>
         {p.children}
     </div>
 )

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -90,7 +90,7 @@ export default class PricingPage extends React.Component<{}, {}> {
                     <div style={{ marginTop: 60 }}>
                         <h4 style={{ color: colors.fontColor2 }}>Pricing</h4>
                         <h1>Free for Open Source</h1>
-                        <p>Choose the subscription that fits you best. Find team subscriptions below.</p>
+                        <p>Choose the plan that fits you best. Find team plans below.</p>
                         <PricingOptions>
                             <PricingBox
                                 title="Open Source"
@@ -142,7 +142,7 @@ export default class PricingPage extends React.Component<{}, {}> {
                 </Container>
                 <Container>
                     <Box
-                        title="Team Subscriptions"
+                        title="Team"
                         style={{
                             paddingLeft: 30,
                             paddingRight: 30,
@@ -153,10 +153,10 @@ export default class PricingPage extends React.Component<{}, {}> {
                         </h3>
                         <div style={{ height: 3, width: 95, backgroundColor: colors.brand, marginBottom: 30 }} />
                         <p>
-                            Manage one subscription for your entire team from a single account.
+                            Manage one plan for your entire team from a single account.
                         </p>
                         <a href="https://gitpod.io/teams">
-                            <button className="primary">Team subscription</button>
+                            <button className="primary">Gitpod for teams</button>
                         </a>
                     </Box>
                 </Container>

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -144,6 +144,7 @@ export default class PricingPage extends React.Component<{}, {}> {
                     <Box
                         title="Team"
                         style={{
+                            marginTop: '1.5rem',
                             paddingLeft: 30,
                             paddingRight: 30,
                             textAlign: 'center',
@@ -274,7 +275,6 @@ class PricingBox extends React.Component<PricingBoxProps, {}> {
         return <Box title={this.props.title} style={{
             width: 260
         }}>
-            <h2 style={{ fontSize: 18, position: 'absolute', top: -34, padding: '0 10px', backgroundColor: colors.background1 }}>{p.title}</h2>
             <p style={{ textAlign: 'center', fontSize: 14, height: 70, paddingTop: 18 }}>
                 {p.description}
             </p>


### PR DESCRIPTION
- Using "plan" instead of "subscription"
- Using "Gitpod for teams" instead of "Team Subscriptions"
- Fixed duplicate title on PricingBoxes (notice the `p` from original title "Open Source" overflowing):

<img width="680" alt="Screenshot 2019-04-03 at 18 32 57" src="https://user-images.githubusercontent.com/599268/55496336-1c587b80-563f-11e9-86bc-60caf5e2a012.png">

Note: This makes Box titles a little bit bigger (same size as "Gitpod for teams" box title), hope that's ok:

<details>
<summary>(old screenshot)</summary>
<img width="680" alt="Screenshot 2019-04-03 at 18 35 19" src="https://user-images.githubusercontent.com/599268/55496447-56c21880-563f-11e9-9496-c856c1fc75ef.png">
</details>