### PR TITLE
[blog] Reduce font-weight just a notch

### DIFF
--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -281,6 +281,7 @@ export default `
           margin-left: 12%;
 
           font-size: 20px;
+          font-weight: 300;
       }
 
       h1 {


### PR DESCRIPTION
I think this tiny change makes the blog even more readable (and more like Medium).

Currently:

<img width="680" alt="Screenshot 2019-04-05 at 12 28 09" src="https://user-images.githubusercontent.com/599268/55621712-93585600-579e-11e9-8aa4-e2298c9a74f8.png">

With this change:

<img width="680" alt="Screenshot 2019-04-05 at 12 28 14" src="https://user-images.githubusercontent.com/599268/55621733-a0754500-579e-11e9-87d7-94690b3b498a.png">