### PR TITLE
Use firefox extension link on firefox

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -194,7 +194,7 @@ export default class IndexPage extends React.Component<{}, IndexPageState> {
 
     protected getHowDoesItWork(): JSX.Element {
         const modes = ['URL Prefix', 'Browser Extension', 'GitHub App'];
-        return <div style={{ minHeight: 550 }}>
+        return <div style={{ minHeight: 550 }} >
             <h2 >Three Ways to Start Coding</h2>
             <div className='flex hidden-md-down' style={{ zIndex: 99 }}>
                 {
@@ -221,7 +221,9 @@ export default class IndexPage extends React.Component<{}, IndexPageState> {
                         <img className='browser-extension-image' src={BrowserExtension} />
                         <div className='browser-extension-description' style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
                             <p>The browser extension adds a button to every GitHub repository, issue and pull request. So you don't have to prefix manually.</p>
-                            <a href={this.getBrowserExtension()} target='_blank'><button className='primary' style={{ minWidth: 200 }}>Get Browser Extension</button></a>
+                            <button className='primary' style={{ minWidth: 200 }} onClick={()=>{
+                                window.open(this.getBrowserExtension(), '_blank');
+                            }}>Get Browser Extension</button>
                         </div>
                     </div>
                     <div className={this.state.worksMode === 2 ? 'selected' : ''}>


### PR DESCRIPTION
I had to change the button to use an `onClick` handler as for some reason the outer `a` tag's href attrobute wasn't updated. Super strange as I could even call `{this.getBrowserExtension()}` in the contents of the button and git the correct mozilla link.
Probably some React caching that I don't understand yet. Would be really awesome to understand what's going on there, but I wanted to get a fix in now :-(