### PR TITLE
State requirement for Debian/Ubuntu based Docker images

### DIFF
--- a/src/docs/42_Config_Docker.md
+++ b/src/docs/42_Config_Docker.md
@@ -23,6 +23,8 @@ There are two ways to configure a custom Docker image in your `.gitpod.yml` file
 
 ## Creating Docker Images for Gitpod
 
+> Note: Gitpod only supports Debian/Ubuntu based images.
+
 A good starting point for creating custom Docker Images is the
 [`gitpod/workspace-full`](https://hub.docker.com/r/gitpod/workspace-full/) image. It already contains all the tools necessary to work with all languages Gitpod supports.
 You can find the source code in [this GitHub repository](https://github.com/gitpod-io/workspace-images).


### PR DESCRIPTION
in response to https://spectrum.chat/gitpod/general/custom-docker-image-ubuntu-debian-only~0498f5cf-2eb7-42c7-8373-c3945469e1bc, but should have been there all along.