### PR TITLE
Rediect to gitpod.io/# if path is empty and hash is not.

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,48 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <script
+            dangerouslySetInnerHTML={{
+                __html: `
+                        if (location.pathname.length <= 1 && location.hash.length > 0) {
+                            window.location.replace("https://gitpod.io/" + window.location.hash);
+                        }
+                    `,
+            }}
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <noscript key="noscript" id="gatsby-noscript">
+          This app works best with JavaScript enabled.
+        </noscript>
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}


### PR DESCRIPTION
So on start page no anchors are allowed.

Fixes gitpod-io/website#43