### PR TITLE
Fix typo following 332799ae2a (fix of gitpod-io/gitpod#621)

### DIFF
--- a/src/docs/52_Tips_and_Tricks.md
+++ b/src/docs/52_Tips_and_Tricks.md
@@ -10,8 +10,8 @@
 ## Command Palette
 
 The _command palette_ is at the core of a keyboard-centric interaction, and can be also useful for
-looking up available commands and key bindings. It is available through the following two keyboard
-shortcuts:
+looking up available commands and key bindings. It is available through the following keyboard
+shortcut:
   - <kbd>F1</kbd>
 
 ![](./images/command_palette.jpg)


### PR DESCRIPTION
Refers to gitpod-io/gitpod#621

This fixes a typo introduced by 332799a