### PR TITLE
Streamline GitHub student developer pack offer

### DIFF
--- a/src/pages/github-student-developer-pack.tsx
+++ b/src/pages/github-student-developer-pack.tsx
@@ -173,7 +173,7 @@ const Styled = styled.div`
 
             @media(max-width: 752px) {
                 position: absolute;
-                top: -920px;
+                top: -985px;
                 transform: translateX(33%);
             }
         }
@@ -196,7 +196,7 @@ const Styled = styled.div`
     .p1 {
         border-color: #FDB02F;
         font-size: 17px;
-        padding-top: 15px;
+        padding-top: 12px;
 
         @media(max-width: ${getEmSize(breakpoints.md - 1)}em) {
             button {
@@ -293,13 +293,11 @@ const CareersPage: React.SFC<{}> = () => (
                 </Offers>
                 <Styled>
                     <p>Always Free for Open Source</p>
-                    <p className="p1">Special offer for the <a href="https://education.github.com/pack" style={{ color: 'inherit', textDecoration: 'underline' }}>GitHub Student Developer Pack</a>
-                    &nbsp;&nbsp;&nbsp;
-                    <a href="https://gitpod.io/subscription/" target="_blank">
-                        <button className='primary' style={{fontSize: 14}}>
-                            Claim Offer
-                            </button>
-                    </a></p>
+                    <p className="p1">
+                        <a href="https://gitpod.io/subscription/" target="_blank">
+                            <button className='primary' style={{fontSize: 14}}>Claim Offer</button>
+                        </a>
+                    </p>
                 </Styled>
             </Container>
             <Highlight>


### PR DESCRIPTION
Removes the link in the "Claim Offer" section and fixes the mobile layout of the page.

Before:
<img width="299" alt="Screenshot 2019-07-18 at 11 55 05" src="https://user-images.githubusercontent.com/3210701/61448714-b2e14c00-a953-11e9-9303-077f55fa6d47.png">

After:
<img width="296" alt="Screenshot 2019-07-18 at 11 54 55" src="https://user-images.githubusercontent.com/3210701/61448723-baa0f080-a953-11e9-852f-5b15451dd61f.png">
<img width="1046" alt="Screenshot 2019-07-18 at 11 55 19" src="https://user-images.githubusercontent.com/3210701/61448735-bffe3b00-a953-11e9-9767-7f588c908726.png">
