### PR TITLE
Fixed.  Image overlapping text issue:- Docs: **Getting Started**

### DIFF
--- a/src/styles/normalize.ts
+++ b/src/styles/normalize.ts
@@ -341,4 +341,8 @@ export default `
         }
     }
   }
+
+  .gatsby-resp-image-wrapper {
+    margin-bottom: 4rem;
+  }
 `


### PR DESCRIPTION
Fixes #268 .
This is what it looks like now:

![image](https://user-images.githubusercontent.com/46004116/67834523-6cca8580-fb09-11e9-9ba6-e03e556295ad.png)
