### PR TITLE
Fixes Tweet collapsing issue.

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -153,6 +153,12 @@ const ResponsiveTweet = styled.div`
         position: static;
         width: 106%;
     }
+
+    @-moz-document url-prefix(){
+        &.firefox--offset {
+            top: 622px !important;
+        }
+    }
 `
 
 const TellMeMore = styled.div`
@@ -487,7 +493,7 @@ export default class IndexPage extends React.Component<{}, IndexPageState> {
                         <ResponsiveTweet style={{ left: 530, top: 360 }}>
                             <TweetEmbed id='1054079167841660928' options={twitterOptions} />
                         </ResponsiveTweet>
-                        <ResponsiveTweet style={{ left: 530, top: 600 }}>
+                        <ResponsiveTweet style={{ left: 530, top: 600 }} className="firefox--offset">
                             <TweetEmbed id='1100698060831764481' options={twitterOptions} />
                         </ResponsiveTweet>
                         <ResponsiveTweet style={{ left: 23, top: 240 }}>


### PR DESCRIPTION
Currently, the last 2 tweets on the bottom right are collapsed and there is no spacing between them. This PR fixes that.

![image](https://user-images.githubusercontent.com/46004116/67918631-ef614c80-fbbe-11e9-8663-142d730db192.png)

This is what it looks like know:

![image](https://user-images.githubusercontent.com/46004116/67918680-2f283400-fbbf-11e9-925d-97eed8154d70.png)

