### PR TITLE
deletes "Explore Gitpod" from different pages.

### DIFF
--- a/src/pages/education.tsx
+++ b/src/pages/education.tsx
@@ -10,7 +10,6 @@ import Quote from '../components/Quote'
 import CollegeStudents from '../resources/college-students.png'
 import Bg from '../components/Bg'
 import ActionCard from '../components/ActionCard'
-import Details from '../components/Details'
 import styled from '@emotion/styled'
 import { colors } from '../styles/variables'
 import PricingTable from '../components/PricingTable'
@@ -227,11 +226,6 @@ const EducationPage: React.SFC<{}> = () => (
             </StyledHeading>
         </div>
 
-        <Details
-            title="Explore Gitpod"
-            text="Learn about collaboration, workspace snapshots, supported programming languages, and much more."
-            anchors={[{href: '/features', text: 'Features'}, {href: '/blog', text: 'See Blog'}]}
-        />
     </IndexLayout>
 )
 

--- a/src/pages/enterprise.tsx
+++ b/src/pages/enterprise.tsx
@@ -9,7 +9,6 @@ import { features } from '../utils/enterprise'
 import Quote from '../components/Quote'
 import Bg from '../components/Bg'
 import ActionCard from '../components/ActionCard'
-import Details from '../components/Details'
 import TrustedBy from '../components/TrustedBy'
 import EnterpriseBg from '../resources/enterprise-bg.png'
 import PricingTable from '../components/PricingTable'
@@ -243,11 +242,6 @@ const EnterprisePage: React.SFC<{}> = () => (
             anchors={[{href: '/schedule-call',text: 'Schedule a Call'}, {href: '/contact', text: 'Contact'}]}
         />
 
-        <Details
-            title="Explore Gitpod"
-            text="Learn about collaboration, workspace snapshots, supported programming languages, and much more."
-            anchors={[{href: '/features', text: 'See Features'}, {href: '/blog', text: 'See Blog'}]}
-        />
     </IndexLayout>
 )
 

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -11,7 +11,6 @@ import { sizes, colors, shadows } from '../styles/variables'
 import { Link } from 'gatsby'
 import CodeReview from '../resources/code-review.png'
 import Circle from '../components/Circle'
-import Details from '../components/Details'
 import ScrollToTopButton from '../components/ScrollToTopButton'
 
 const StyledFeaturesPage = styled.div`
@@ -333,14 +332,6 @@ const FeaturesPage: React.SFC<{}> = () => (
                         <h3>Prefix any GitHub or GitLab URL with <span>gitpod.io/#</span></h3>
                     </section>
                 </div>
-
-                {/* ----- Explore Gitpods ----- */}
-
-                <Details
-                    title="Explore Gitpod"
-                    text="Learn about collaboration, workspace snapshots, supported programming languages, and much more."
-                    anchors={[{href: '/pricing', text: 'See Pricing'}, {href: '/blog', text: 'See Blog'}]}
-                />
 
         </StyledFeaturesPage>
     </IndexLayout>

--- a/src/pages/recruiting.tsx
+++ b/src/pages/recruiting.tsx
@@ -10,7 +10,6 @@ import Quote from '../components/Quote'
 import RecruitingBG from '../resources/recruiting-bg.png'
 import Bg from '../components/Bg'
 import ActionCard from '../components/ActionCard'
-import Details from '../components/Details'
 import PricingTable from '../components/PricingTable'
 import Circle from '../components/Circle'
 import Layer from '../resources/layer.svg'
@@ -203,13 +202,6 @@ const RecrutingPage: React.SFC<{}> = () => (
             text='Please, get in touch. We’re happy to answer your questions.'
             anchors={[{href: '/schedule-call',text: 'Schedule a Call'}, {href: '/contact', text: 'Contact'}]}
         />
-
-        <Details
-            title="Explore Gitpod"
-            text="Learn about collaboration, workspace snapshots, supported programming languages, and much more."
-            anchors={[{href: '/features', text: 'See Features'}, {href: '/blog', text: 'See Blog'}]}
-        />
-
 
     </IndexLayout>
 )

--- a/src/pages/vendor.tsx
+++ b/src/pages/vendor.tsx
@@ -10,7 +10,6 @@ import Quote from '../components/Quote'
 import VendorBG from '../resources/vendor-bg.png'
 import Bg from '../components/Bg'
 import ActionCard from '../components/ActionCard'
-import Details from '../components/Details'
 import PricingTable from '../components/PricingTable'
 import Circle from '../components/Circle'
 import Layer from '../resources/layer.svg'
@@ -198,11 +197,6 @@ const VendorPage: React.SFC<{}> = () => (
             anchors={[{href: '/schedule-call',text: 'Schedule a Call'}, {href: '/contact', text: 'Contact'}]}
         />
 
-        <Details
-            title="Explore Gitpod"
-            text="Learn about collaboration, workspace snapshots, supported programming languages, and much more."
-            anchors={[{href: '/features', text: 'See Features'}, {href: '/blog', text: 'See Blog'}]}
-        />
     </IndexLayout>
 )
 


### PR DESCRIPTION
This PR deletes section Explore Gitpod as specified in #280 
![image](https://user-images.githubusercontent.com/46004116/70608129-73c4d780-1c21-11ea-8125-307ee6e89f41.png)
 