### PR TITLE
[self-hosted] Better illustrative install steps?

### DIFF
--- a/src/blog/self-host-your-gitpod.md
+++ b/src/blog/self-host-your-gitpod.md
@@ -47,9 +47,9 @@ All it needs to get it running on your infrastructure is to have a domain name a
 
 1. In your terminal, run: `git clone https://github.com/gitpod-io/self-hosted`
 
-2. Adjust the configuration from the repository to your needs.
+2. Adjust configuration files like `values.yaml` to your needs
 
-3. Run `helm install -f ... gitpod`
+3. Run `helm install -f values.yaml gitpod .`
 
 [The setup for vanilla Kubernetes](/docs/self-hosted/latest/install/10_install_on_kubernetes/) will work most Kubernetes clusters.
 For Google Cloud Platform (GCP) we offer a [script that automates the install](/docs/self-hosted/latest/install/11_install_on_gcp_script/).

--- a/src/pages/self-hosted.tsx
+++ b/src/pages/self-hosted.tsx
@@ -123,18 +123,18 @@ const SelfHostedPage: React.SFC<{}> = () => (
                         <ol className="install__steps">
                             <li className="install__step">
                                 <span>1.</span>
-                                <StepP>In your terminal run:</StepP>
+                                <StepP>In your terminal, run:</StepP>
                                 <Terminal>
                                     git clone <a href="https://github.com/gitpod-io/self-hosted" target="_blank">https://github.com/gitpod-io/self-hosted</a>
                                 </Terminal>
                             </li>
                             <li className="install__step">
-                                <span>2.</span><StepP>Adjust the configuration from the repository to your needs.</StepP>
+                                <span>2.</span><StepP>Adjust configuration files like `values.yaml` to your needs</StepP>
                             </li>
                             <li className="install__step">
                                 <span>3.</span><StepP>Run</StepP>
                                 <Terminal>
-                                    helm install -f ... gitpod
+                                    helm install -f values.yaml gitpod .
                                 </Terminal>
                             </li>
                         </ol>


### PR DESCRIPTION
That way, the commands actually "work" (will likely tell you that you need to do more stuff, but at least the example commands are valid and you can iterate from there).

Also, I think it's useful to tip off users about `values.yaml` being an important file (otherwise, you don't know any configuration files that you can change).