### PR TITLE
[self-hosted][docs] Fix some typos, dead links missing information

### DIFF
--- a/src/docs/self-hosted/0.3.0/install/01_prepare_installation.md
+++ b/src/docs/self-hosted/0.3.0/install/01_prepare_installation.md
@@ -38,7 +38,7 @@ Gitpod supports the following authentication providers:
 ## HTTPS certificates (Optional)
 While we highly recommend operating Gitpod using HTTPS, Gitpod is able to run on insecure HTTP.
 The caveat of using HTTP is that the builtin Docker registry will not function as Docker/containerd do not pull from insecure registries by default.
-You can either resort to using an [external registry](#docker-registry-optional) or use HTTPS. For running Gitpod on insecure HTTP, no HTTPS certificates are needed and you can skip this paragraph.
+You can either resort to using an [external registry](#docker-registry-optional) or use HTTPS. For running Gitpod on insecure HTTP, no HTTPS certificates are needed and you can skip this section.
 
 The most accessible means of obtaining HTTPS certificates is using [Let's Encrypt](https://letsencrypt.org/) which provides free certificats to anybody who can prove ownership of a domain.
 Gitpod requires [wildcard certificates](https://en.wikipedia.org/wiki/Wildcard_certificate) (e.g. `*.ws.your-domain.com`) which [can be obtained via Let's Encrypt](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) but require [proof of ownership via DNS](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
@@ -48,7 +48,7 @@ Things get considerably easier when your domain is registered with a service for
 See [here](../34_https_certs/) for more details on how the certificates are used during installation.
 
 ## MySQL Database (Optional)
-Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in. If you operate your own MySQL database (which we'd recommend in a production setting) you can use that one:
+Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in. If you operate your own MySQL database (which we'd recommend in a production setting) you can use that one. You have the following options:
 
 * Integrated database: If not disabled, this MySQL database is installed in a Kubernetes pod as a part of Gitpod’s Helm chart.
 The database uses a Kubernetes PersistentVolume. We do not recommend using this option fo a production setting.
@@ -59,7 +59,7 @@ The database uses a Kubernetes PersistentVolume. We do not recommend using this 
 Gitpod builds Docker images during workspace startup. This enables custom Dockerfiles as part of your workspace config, but is also required for Gitpod itself to function.
 To this end, Gitpod requires a container registry where it can push the images it builds.
 
-By default Gitpod ships with a Docker registry built-in. If you operate your own Docker registry (which we'd recommend in a production setting) you can use that one:
+By default Gitpod ships with a built-in Docker registry. If you operate your own Docker registry (which we'd recommend in a production setting) you can use that one. You have the following options:
 
 * Integrated docker registry: If not disabled, this docker registry is installed in a Kubernetes Pod as a dependency of Gitpod’s Helm chart.
   The docker registry requires a Kubernetes PersistentVolume. This registry is not recommended to be used for production.
@@ -68,7 +68,7 @@ By default Gitpod ships with a Docker registry built-in. If you operate your own
 ## Bucket Storage (Optional)
 Gitpod uses bucket storage to persist the contents of workspaces. Each workspace tarballed into a single archive file which is then uploaded to the bucket.
 
-By default Gitpod ships with [MinIO](https://min.io/) as built-in bucket storage. If you operate your own MinIO instance, or have access to Google Cloud Bucket storage you can use that one:
+By default Gitpod ships with [MinIO](https://min.io/) as built-in bucket storage. If you operate your own MinIO instance, or have access to Google Cloud Bucket storage you can use that one. You have the following options:
 
 * Integrated MinIO: If not disabled, Gitpod installs MinIO in Kubernetes as a dependency of Gitpod’s helm charts.
   MinIO itself can serve as [gateway](https://github.com/minio/minio/tree/master/docs/gateway) to other storage providers.

--- a/src/docs/self-hosted/0.3.0/install/10_install_on_kubernetes.md
+++ b/src/docs/self-hosted/0.3.0/install/10_install_on_kubernetes.md
@@ -4,7 +4,7 @@ Gitpod also provides more optimized installations offering better performance fo
 * *Google Cloud Platform*: Install Gitpod in a blank GCP project, either [using a script that automates the procedure](../11_install_on_gcp_script/) or [manually step-by-step](../12_install_on_gcp_manual/).
 
 ## Prerequisites
-- Ensure you have the [general installation prerequisites](../01_prepare_installation/) avilable.
+- Ensure you have the [general installation prerequisites](../01_prepare_installation/) available.
 - `kubectl` with access to that cluster.
 - `helm`. We recommend version 3.x. Any version >= 2.11 will also work, but requires you to have [tiller configured](../90_helm_2x/).
 

--- a/src/docs/self-hosted/0.3.0/install/11_install_on_gcp_script.md
+++ b/src/docs/self-hosted/0.3.0/install/11_install_on_gcp_script.md
@@ -5,19 +5,18 @@ However, Gitpod sports a range of integrations with the Google Cloud Platform th
 This section describes the neccesary steps to prepare a new GCP project for a Gitpod installation.
 
   > We have automated this process. If you want to get up and running as quickly as possible, that's the way to go.
-  > See the [automated setup](#automated-setup) section for details.
 
-You can perform the set up of the GCP resources yourself. See the [manual GCP setup](12_install_on_gcp_manual) section for more details.
+You can perform the set up of the GCP resources yourself. See the [manual GCP setup](../12_install_on_gcp_manual/) section for more details.
 
 This installation script configures your GCP project and produces the required Helm configuration for installing Gitpod in that project.
-Once all GCP setup is complete, you will only have to manually set up [OAuth](30_oauth) and optionally [HTTPS](34_https_certs).
+Once all GCP setup is complete, you will only have to manually set up [OAuth](../30_oauth/) and optionally [HTTPS](../34_https_certs/).
 
 You can install Gitpod self-hosted in your GCP project from within Gitpod. This way you don't have to install the Google Cloud SDK or other required tools.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/self-hosted)
 
 ## Prerequisites
-- Ensure you have the [general installation prerequisites](../01_prepare_installation/) avilable.
+- Ensure you have the [general installation prerequisites](../01_prepare_installation/) available.
 - [Google Could SDK](https://cloud.google.com/sdk/install)
 - [Go (at least 1.12)](https://golang.org/doc/install)
 - mysql client
@@ -26,13 +25,15 @@ You can install Gitpod self-hosted in your GCP project from within Gitpod. This 
 
 The [Gitpod self-hosted repository](https://github.com/gitpod-io/self-hosted) contains the configuration files this guide is refering to.
 The installation script will modify the configuration files found in that repository.
-We recommend you fork this repository so that you can easily rebase your changes on the latest version.
+We recommend you to fork this repository so that you can easily rebase your changes on the latest version.
 
 ```
 git clone https://github.com/gitpod-io/self-hosted
 cd self-hosted
 git remote rename origin upstream
 ```
+
+Configure at least your `values.yaml`. Set your domain and the [OAuth](../30_oauth/) section.
 
 ## Installation
 To start the automated setup, run [`./utils/create-gcp-resources.go`](https://github.com/gitpod-io/self-hosted/blob/master/utils/create-gcp-resources.go) from the root of the self-hosted repo.

--- a/src/docs/self-hosted/0.3.0/install/34_https_certs.md
+++ b/src/docs/self-hosted/0.3.0/install/34_https_certs.md
@@ -1,6 +1,6 @@
 ### HTTPS certificates
 
-Gitpod needs HTTPS certificates, your own Docker registry, or both to function properly. If you don't have certificates, but a Docker registry available, jump to step 3.
+Gitpod needs HTTPS certificates, your own Docker registry, or both to function properly. If you don't have certificates, but a Docker registry available, jump to the [next step](../35_docker_registry/).
 
 > Important: The HTTPS certificates for your domain must include `your-domain.com`, `*.your-domain.com` and `*.ws.your-domain.com`. Beware that wildcard certificates are valid for one level only (i.e. `*.a.com` is not valid for `c.b.a.com`).
 

--- a/src/docs/self-hosted/0.3.0/install/35_docker_registry.md
+++ b/src/docs/self-hosted/0.3.0/install/35_docker_registry.md
@@ -1,10 +1,10 @@
 # Docker Registry
 
-Gitpod uses a Docker registry to push the workspace images it builds. 
-This helm chart can either deploy its own registry (default but requires HTTPS certs, see above) or use an existing one. 
+Gitpod uses a Docker registry to push the workspace images it builds.
+This helm chart can either deploy its own registry (default but requires [HTTPS certs](../34_https_certs/)) or use an existing one.
 To connect to an existing Docker registry,
  - `echo values/registry.yaml >> configuration.txt`
  - in `values/registry.yaml` replace `your.registry.com` with the name of your registry
- - login to the registry and safe the authentication `docker --config secrets/ login your.registry.com && mv secrets/config.json secrets/registry-auth.json`. 
-   Make sure the resulting JSON file contains the credentials (there should be an `auth` section containing them as base64 encoded string). 
+ - login to the registry and safe the authentication `docker --config secrets/ login your.registry.com && mv secrets/config.json secrets/registry-auth.json`.
+   Make sure the resulting JSON file contains the credentials (there should be an `auth` section containing them as base64 encoded string).
    If that's not the case you might have a credential store/helper set up (e.g. on macOS the _Securely store Docker logins in macOS keychain_ setting).


### PR DESCRIPTION
There are some dead links and typos in the self-hosted documentation that this commit fixes. It also add some minor additions that I found useful to know while testing Gitpod self-hosted.