### PR TITLE
[trusted-by] make FCC logo bigger for mobile devices.

### DIFF
--- a/src/components/TrustedBy.tsx
+++ b/src/components/TrustedBy.tsx
@@ -39,6 +39,14 @@ const StyledTrustedBy = styled.section`
             grid-template-columns: repeat(1, 1fr);
         }
     }
+
+    .fcc {
+        transform: scale(1.05);
+
+        @media(max-width: ${sizes.breakpoints.sm}) {
+            transform: scale(1.3);
+        }
+    }
 `
 
 const StyledBrandImage = styled.img<{transform?: string}>`
@@ -54,7 +62,8 @@ interface Brand {
     alt: string
     url: string
     svg: string
-    transform?: string
+    transform?: string,
+    className?: string 
 }
 
 interface TrustedByProps {
@@ -70,7 +79,12 @@ const TrustedBy: React.SFC<TrustedByProps> = ({brands}) => (
                         {
                             brands.map((b, i) => (
                                 <a href={b.url} target="_blank" key={i}>
-                                    <StyledBrandImage src={b.svg} alt={b.alt} transform={b.transform}/>
+                                    <StyledBrandImage 
+                                        src={b.svg} 
+                                        alt={b.alt} 
+                                        transform={b.transform}
+                                        className={b.className}
+                                    />
                                 </a>
                             ))
                         }

--- a/src/pages/enterprise.tsx
+++ b/src/pages/enterprise.tsx
@@ -93,7 +93,7 @@ const EnterprisePage: React.SFC<{}> = () => (
                     alt: 'freeCodeCamp.org',
                     url: 'https://www.freecodecamp.org/',
                     svg: FreeCodeCamp,
-                    transform: 'scaleY(1.3)'
+                    className: 'fcc'
                 },
                 {
                     alt: 'Gatsby Logo',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -506,7 +506,7 @@ const IndexPage: React.SFC<{}> = () => (
                         alt: 'freeCodeCamp.org',
                         url: 'https://www.freecodecamp.org/',
                         svg: FreeCodeCamp,
-                        transform: 'scaleY(1.3)'
+                        className: 'fcc'
                     },
                     {
                         alt: 'Gatsby Logo',


### PR DESCRIPTION
Fixes gitpod-io/website#379

This is what it looks like now: 

![image](https://user-images.githubusercontent.com/46004116/71815882-ac31c700-30a2-11ea-9347-060b47849515.png)
