### PR TITLE
[setup] add: extensions for css-in-js support.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,8 @@ tasks:
   command: yarn dev --host 0.0.0.0
 - init: cd plugins/gatsby-remark-gitpod && npm install
   openMode: split-right
+vscode:
+  extensions:
+    - jpoissonnier.vscode-styled-components@0.0.28:Qde/ISuGvFTPjoaMf1FmnQ==
+    - paulmolluzzo.convert-css-in-js@1.1.3:YnjK47pXScU3DMFfQzkkOw==
+    


### PR DESCRIPTION
This PR adds vscode extensions for CSS-IN-JS support (i.e for things like IntelliSense & syntax highlighting & so on).
