### PR TITLE
[docs] Small tweaks to 'Julia in Gitpod'

### DIFF
--- a/src/docs/julia-in-gitpod.md
+++ b/src/docs/julia-in-gitpod.md
@@ -1,11 +1,8 @@
 # Julia in Gitpod
 
-It's relatively easy to set up your Julia project in Gitpod.
+## Examples
 
-## Workspace Configuration
+A minimal example of a ready-to-code Julia development environment is [JesterOrNot/Gitpod-Julia](https://github.com/JesterOrNot/Gitpod-Julia). Feel free to take a look.
 
-A great minimal example of a ready-to-code Julia development environment is [JesterOrNot/Gitpod-Julia](https://github.com/JesterOrNot/Gitpod-Julia).
-
-To showcase a real-world Julia project in Gitpod, we've gitpodified the Julia Programming Language repository itself! Try it here:
-
+And to showcase a real-world Julia project in Gitpod, we've gitpodified the [Julia repository](https://github.com/JesterOrNot/Julia) itself! Try it here:
 [![JesterOrNot/Julia](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Julia)

--- a/src/docs/languages-and-frameworks.md
+++ b/src/docs/languages-and-frameworks.md
@@ -4,7 +4,7 @@ Below is a list of language and framework specific tips & tricks.
 
   * [Java](/docs/java-in-gitpod/)
   * [Python](/docs/python-in-gitpod/)
-  * [Julia](/docs/julia-in-gitpod/)
   * [Go](/docs/go-in-gitpod/)
   * [Ruby](/docs/ruby-in-gitpod)
   * [Rust](/docs/rust-in-gitpod/)
+  * [Julia](/docs/julia-in-gitpod/)

--- a/src/docs/menu.ts
+++ b/src/docs/menu.ts
@@ -123,10 +123,6 @@ export const MENU: MenuEntry[] = [
                 "python-in-gitpod"
             ),
             M(
-                "Julia",
-                "julia-in-gitpod"
-            ),
-            M(
                 "Go",
                 "go-in-gitpod"
             ),
@@ -137,6 +133,10 @@ export const MENU: MenuEntry[] = [
             M(
                 "Rust",
                 "rust-in-gitpod"
+            ),
+            M(
+                "Julia",
+                "julia-in-gitpod"
             )
         ]
     ),

--- a/src/docs/ruby-in-gitpod.md
+++ b/src/docs/ruby-in-gitpod.md
@@ -8,7 +8,7 @@ Gitpod comes with Ruby 2.5 and 2.6 pre-installed (2.6 is the default).
 To change the default Ruby version, you can simply run `rvm use 2.5 --default` in Gitpod's Terminal. You can also install other versions, e.g. by running `rvm install 2.7`.
 
 ## Examples
-Before we begin, here are some example Ruby projects that are automated with Gitpod:
+Here are some example Ruby projects that are automated with Gitpod:
 
 Repository | Description | Try it
 ---------|----------|---------


### PR DESCRIPTION
I've simplified the Julia guide a little bit, and also moved it further down the list of languages, because the language is less popular in Gitpod and the guide is also shorter than others.

@JesterOrNot please take a look.