### PR TITLE
[nav] Make "Log In" button open Gitpod login page, not workspaces

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -297,7 +297,7 @@ class Nav extends React.Component {
                                             ]}
                                         />
                                     </li>
-                                    <li className="nav__item"><a href="https://gitpod.io/workspaces/" tabIndex={ isNavRendered ? 0 : -1 } rel="noopener" className="btn">Log In</a></li>
+                                    <li className="nav__item"><a href="https://gitpod.io/login/" tabIndex={ isNavRendered ? 0 : -1 } rel="noopener" className="btn">Log In</a></li>
                                 </ul>
                             ) : null }
                     </StyledNav>


### PR DESCRIPTION
Currently, you need to click on a "Log In" button twice, which is annoying / surprising.