### PR TITLE
[docs] Use official Servo repository in Rust guide (instead of my personal fork)

### DIFF
--- a/src/docs/rust-in-gitpod.md
+++ b/src/docs/rust-in-gitpod.md
@@ -32,7 +32,7 @@ Here are some examples of Rust projects running in Gitpod:
 |---------|------------|-----|
 |[MathLang](https://github.com/JesterOrNot/mathlang) | Basic maths language in Rust | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/MathLang) |
 |[NuShell](https://github.com/nushell/nushell/) | A next gen shell for the GitHub era | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nushell/nushell) |
-|[Servo](https://github.com/jankeromnes/servo) | The Servo Browser Engine | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://https://github.com/jankeromnes/servo)
+|[Servo](https://github.com/servo/servo) | The Servo Browser Engine | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/servo/servo)
 
 </div>
 


### PR DESCRIPTION
The Gitpod config I try to maintain for https://github.com/servo/servo lives in https://github.com/gitpod-io/definitely-gp/tree/master/servo