### PR TITLE
Improve 'Garbage Collection' text in 'Live of a Workspace'

### DIFF
--- a/src/docs/life-of-workspace.md
+++ b/src/docs/life-of-workspace.md
@@ -4,15 +4,15 @@
  * [Garbage Collection](#garbage-collection)
  * [Changes Are Saved](#changes-are-saved)
 
-Gitpod makes creating fresh workspaces as easy as clicking a button on a GitHub page.
+Gitpod makes creating fresh workspaces as easy as [clicking a button on a GitHub page](/docs/browser-extension/).
 Gitpod's continuous dev environments encourages you to create fresh workspaces rather than restarting older ones.
 This ensures that you are starting from a clean slate with proper configuration.
 
 ## Timeouts
-Any running workspace will automatically stop after some time of inactivity. Normally, this timeout is 30 minutes but is extended to __60 minutes if you have the _Unlimited plan__.
+Any running workspace will automatically stop after some time of inactivity. Normally, this timeout is 30 minutes but is extended to __60 minutes if you have the _Unlimited_ plan__.
 Furthermore, _Unlimited_ users can manually boost the timeout of a workspace to 180 minutes. This comes in handy, e.g. in case you want to go out for a longer lunch or meeting and don't like restarting your workspace when coming back.
 
-The timeout will always be reset to the full 30 mins (or whatever is enabled) by any action - mouse move or keystroke - in the IDE.
+The timeout will always be reset to the full 30 minutes (or other applicable timeout depending on your subscription) by any activity&thinsp;—&thinsp;mouse move or keystroke&thinsp;—&thinsp;in the IDE.
 If the IDE is still open but the corresponding workspace has stopped, a dialog will pop up that lets you start the workspace
 again. Alternatively, you can just reload the browser or go to your [workspaces](https://gitpod.io/workspaces) and restart the workspace.
 
@@ -23,4 +23,4 @@ Old, unused workspaces are automatically deleted. To prevent a workspace from be
 
 ## Changes are Saved
 Gitpod backs up the state of the `/workspace/` folder between workspace starts, so that
-you can revisit them later. Files in other locations will not be saved!
+you can revisit them later. _Attention: Files in other locations will not be saved!_

--- a/src/docs/life-of-workspace.md
+++ b/src/docs/life-of-workspace.md
@@ -1,7 +1,7 @@
 # Life of a Workspace
 
  * [Timeouts](#timeouts)
- * [Stop and Archive](#stop-and-archive)
+ * [Garbage Collection](#garbage-collection)
  * [Changes Are Saved](#changes-are-saved)
 
 Gitpod makes creating fresh workspaces as easy as clicking a button on a GitHub page.
@@ -19,8 +19,7 @@ again. Alternatively, you can just reload the browser or go to your [workspaces]
 For convenience, closing the browser window/tab containing the IDE reduces the timeout to 3 minutes.
 
 ## Garbage Collection
-Old unused workspaces are automatically deleted after 30 days of inactivity. To prevent a workspace from being deleted you can pin it on your [list of workspaces](https://gitpod.io/workspaces).
-Restarting a workspace resets the 30 day timeout.
+Old, unused workspaces are automatically deleted. To prevent a workspace from being deleted, you can pin it in your [list of workspaces](https://gitpod.io/workspaces/). Pinned workspaces are kept forever. A message at the top of the workspaces list indicates after how many days unused and unpinned workspaces will get collected (the exact number of days may change in the future). Restarting a workspace resets the day counter for this particular workspace. Workspaces that are about to be deleted are shown with a corresponding status message in the workspaces list.
 
 ## Changes are Saved
 Gitpod backs up the state of the `/workspace/` folder between workspace starts, so that


### PR DESCRIPTION
- The 30 days until the GC strikes is not correct and is subject to change in the future again. Removed the fixed number and pointed to the message above the workspace list.
- I have expanded the explanation a little bit in general.
- Fixed page TOC.

Bonus:
- Add typo fixes and smaller improvements to 'Live of a Workspace' page.