### PR TITLE
[docs] oauth change long lines of code to code blocks.

### DIFF
--- a/src/docs/self-hosted/0.3.0/install/oauth.md
+++ b/src/docs/self-hosted/0.3.0/install/oauth.md
@@ -5,7 +5,12 @@ Currently Gitpod supports GitHub, GitHub Enterprise and GitLab.
 ## GitHub
 To authenticate your users with GitHub you need to create a [GitHub OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
 Follow the guide linked above and:
-   - set "Authentication callback URL" to: `https://<your-domain.com>/auth/github/callback`
+   - set "Authentication callback URL" to: 
+
+       
+    https://<your-domain.com>/auth/github/callback
+    
+ 
    - copy the following values and configure them in `values.yaml`:
       - `clientId`
       - `clientSecret`
@@ -13,7 +18,10 @@ Follow the guide linked above and:
 ## GitLab
 To authenticate your users with GitLab you need to create an [GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html).
 Follow the guide linked above and:
-   - set "Authentication callback URL" to: `https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback`
+   - set "Authentication callback URL" to: 
+   
+    https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
+
    - set "Scopes" to `api`, `read_user` and `read_repository`.
    - copy the following values and configure them in `values.yaml`:
       - `clientId` is the "Application ID" from the GitLab OAuth appication


### PR DESCRIPTION
Fixes #503 

This is how it looks: 

![image](https://user-images.githubusercontent.com/46004116/75440746-246b8900-597e-11ea-87c1-d287b2969ce1.png)
