### PR TITLE
[blog][docs] Use better URL for GitHub App

### DIFF
--- a/src/blog/gitpod-launch.md
+++ b/src/blog/gitpod-launch.md
@@ -40,7 +40,7 @@ There is an additional bit of friction that every developer has to go through re
 
 Running the build and downloading dependencies.
 
-Starting today, [the new Gitpod app is available on the GitHub marketplace](https://github.com/marketplace/gitpod-io). It is the first of its kind and the only one in the new IDE category.
+Starting today, [the new Gitpod app is available on the GitHub marketplace](https://github.com/apps/gitpod-io). It is the first of its kind and the only one in the new IDE category.
 
 Once you've installed the app for your GitHub repository, it will pre-build dev environments on every commit. So when anybody opens a Gitpod environment on your project, the dev environment is opened as described above. But now also the build ran through and all dependencies are already there.
 

--- a/src/blog/gitpodify.md
+++ b/src/blog/gitpodify.md
@@ -62,7 +62,7 @@ Do you wish Gitpod would do more for your project? Then please read on. 👇
 
 ## Running init scripts
 
-Adding a `.gitpod.yml` file at the root of your repository allows customizing Gitpod for your project. A useful thing it can do is running scripts on start-up (or sometimes even before start-up: the [Gitpod app](https://github.com/marketplace/gitpod-io) can watch your repo and start pre-building the `init` step for every commit, see the next section for more info):
+Adding a `.gitpod.yml` file at the root of your repository allows customizing Gitpod for your project. A useful thing it can do is running scripts on start-up (or sometimes even before start-up: the [Gitpod app](https://github.com/apps/gitpod-io) can watch your repo and start pre-building the `init` step for every commit, see the next section for more info):
 
 ```yml
 tasks:
@@ -105,7 +105,7 @@ To learn more about configuring Terminals, please visit [the docs](https://www.g
 
 With medium-to-large GitHub projects, your `init` step might take a long time to complete, especially if you need to compile code. To avoid that you and your contributors wait forever, you can make Gitpod auto-build your repository on every push, and start building workspaces even before Gitpod is opened. This will shave up to several minutes off your workspace loading times, and make your developers very happy.
 
-To enable prebuilt workspaces, simply install the [Gitpod app](https://github.com/marketplace/gitpod-io) for your GitHub repository, and Gitpod will start auto-building all your branches and Pull Requests continuously in the background.
+To enable prebuilt workspaces, simply install the [Gitpod app](https://github.com/apps/gitpod-io) for your GitHub repository, and Gitpod will start auto-building all your branches and Pull Requests continuously in the background.
 
 Optionally, you can then customize the app's behavior for your project by editing your `.gitpod.yml` like so:
 

--- a/src/docs/release-notes/2019-04-05/april-2019.md
+++ b/src/docs/release-notes/2019-04-05/april-2019.md
@@ -9,7 +9,7 @@ Besides a complete relaunch of the website and app, we have added some very exci
 
 ## GitHub App / Prebuilt Workspaces 🚀
 
-We have been busy developing a <a href="https://github.com/marketplace/gitpod-io" target="_blank">new GitHub app</a>, that once installed on your repository will prebuild your project on every push.
+We have been busy developing a <a href="https://github.com/apps/gitpod-io" target="_blank">new GitHub app</a>, that once installed on your repository will prebuild your project on every push.
 On GitHub pull requests this is communicated through a status check.
 
 ![Prebuilt Check on PR](./img/prebuilt-check.png)

--- a/static/release-notes/2019-04-05/april-2019.md
+++ b/static/release-notes/2019-04-05/april-2019.md
@@ -9,7 +9,7 @@ Besides a complete relaunch of the website and app, we have added some very exci
 
 ## GitHub App / Prebuilt Workspaces 🚀
 
-We have been busy developing a <a href="https://github.com/marketplace/gitpod-io" target="_blank">new GitHub app</a>, that once installed on your repository will prebuild your project on every push.
+We have been busy developing a <a href="https://github.com/apps/gitpod-io" target="_blank">new GitHub app</a>, that once installed on your repository will prebuild your project on every push.
 On GitHub pull requests this is communicated through a status check.
 
 ![Prebuilt Check on PR](./img/prebuilt-check.png)


### PR DESCRIPTION
https://github.com/apps/gitpod-io intuitively allows configuring the app for your account or for an organization.

https://github.com/marketplace/gitpod-io doesn't, and is confusing (Gitpod is not allowed for orgs?!)