### PR TITLE
Minor fixes to start tasks documentation

### DIFF
--- a/src/docs/config-start-tasks.md
+++ b/src/docs/config-start-tasks.md
@@ -10,8 +10,10 @@ For instance, the start script for the Gitpod documentation repository is define
 
 ```yaml
 tasks:
-- init: yarn && yarn build
-  command: yarn dev --host 0.0.0.0
+  - init: yarn && yarn build
+    command: yarn dev --host 0.0.0.0
+  - init: cd plugins/gatsby-remark-gitpod && npm install
+    openMode: split-right
 ```
 
 You can have multiple tasks, which are opened on separated terminals.
@@ -67,7 +69,7 @@ In case you need to run something even before init, that is a requirement for bo
 
 ```yaml
 tasks:
-  - before: setup.sh
+  - before: ./setup.sh
     init: npm install
     command: npm run dev
 ```
@@ -100,10 +102,10 @@ You can configure where in the IDE the terminal should be opened:
 
 | openIn       | Where |
 | ---------------|---------------------------|
-| `openIn:bottom`| the bottom panel (default)|
-| `openIn:left`  | the left panel|
-| `openIn:right` | the right panel|
-| `openIn:main`  | the main editor area|
+| `openIn: bottom`| the bottom panel (default)|
+| `openIn: left`  | the left panel|
+| `openIn: right` | the right panel|
+| `openIn: main`  | the main editor area|
 
 </div>
 
@@ -115,11 +117,11 @@ You can configure how the terminal should be opened relative to the previous tas
 
 | openMode        | Description |
 | --------------- | ----------- |
-| `openMode:tab-after`     | Opens in the same tab group right after the previous tab |
-| `openMode:tab-before`    | Opens in the same tab group left before the previous tab |
-| `openMode:split-right`   | Splits and adds the terminal to the right |
-| `openMode:split-left`    | Splits and adds the terminal to the left |
-| `openMode:split-top`     | Splits and adds the terminal to the top |
-| `openMode:split-bottom`  | Splits and adds the terminal to the bottom |
+| `openMode: tab-after`     | Opens in the same tab group right after the previous tab |
+| `openMode: tab-before`    | Opens in the same tab group left before the previous tab |
+| `openMode: split-right`   | Splits and adds the terminal to the right |
+| `openMode: split-left`    | Splits and adds the terminal to the left |
+| `openMode: split-top`     | Splits and adds the terminal to the top |
+| `openMode: split-bottom`  | Splits and adds the terminal to the bottom |
 
 </div>

--- a/src/docs/config-start-tasks.md
+++ b/src/docs/config-start-tasks.md
@@ -12,8 +12,6 @@ For instance, the start script for the Gitpod documentation repository is define
 tasks:
   - init: yarn && yarn build
     command: yarn dev --host 0.0.0.0
-  - init: cd plugins/gatsby-remark-gitpod && npm install
-    openMode: split-right
 ```
 
 You can have multiple tasks, which are opened on separated terminals.


### PR DESCRIPTION
Minor fixes to start tasks documentation

- Syntax errors: both the openMode table and the openIn table had no space between the colon and the value i.e. `openMode:split-left` causes a syntax error so I replaced it with `openMode: split-left`
- Outdated section: early in the docs we say here is our setup but we have a second part of the init section, so I added it
- Minor fixes: in the before task section we have the following
```yaml
tasks:
  - before: setup.sh
    init: npm install
    command: npm run dev
```
I sincerely doubt that `setup.sh` is in `$PATH` so I changed it to `./setup.sh`