### PR TITLE
change links from personal repo to gitpod org

### DIFF
--- a/src/docs/languages/bash.md
+++ b/src/docs/languages/bash.md
@@ -30,7 +30,7 @@ USER gitpod
 RUN brew install shellcheck
 ```
 
-You should also install the shellcheck VS Code extension in Gitpod, by adding a [.gitpod.yml](https://www.gitpod.io/docs/41_config_gitpod_file/) configuration file to your repository that looks like this (notice the `vscode` extensions section):
+You should also install the shellcheck VS Code extension in Gitpod, by adding a [.gitpod.yml](/docs/config-gitpod-file/) configuration file to your repository that looks like this (notice the `vscode` extensions section):
 
 ```yaml
 image:
@@ -43,22 +43,22 @@ vscode:
 
 Not sure about ShellCheck? Try it in Gitpod!
 
-[![JesterOrNot/Gitpod-ShellCheck](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-ShellCheck)
+[![gitpod-io/Gitpod-ShellCheck](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-ShellCheck)
 
 ### Bash IDE
 
 ![A Bash IDE demonstration](../images/bashIDE.png)
-<br/>
+
 Just to name a few things Bash IDE adds: Code completion, hovers, and diagnostic reporting.
 
-To install Bash IDE to your repository add the following to your [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/)
+To install Bash IDE to your repository add the following to your [.gitpod.Dockerfile](/docs/config-docker/)
 
 ```dockerfile
 RUN npm i -g bash-language-server
 ```
 
 Also the following in your
-[.gitpod.yml](https://www.gitpod.io/docs/41-config-gitpod-file/)
+[.gitpod.yml](/docs/config-gitpod-file/)
 
 ```yaml
 vscode:
@@ -68,8 +68,8 @@ vscode:
 
 Not sure about Bash IDE? Try it in Gitpod
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-BashIDE)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-BashIDE)
 
 ## External Resources
 
-- For more on ShellCheck see https://shellcheck.net
+- For more information about ShellCheck please see [shellcheck.net](https://shellcheck.net)

--- a/src/docs/languages/go.md
+++ b/src/docs/languages/go.md
@@ -121,9 +121,9 @@ Then, simply open the Go file you want to debug, open the Debug panel (in the le
 <br>
 
 
-To see a basic repository with Go debugging enabled, please check out [JesterOrNot/Gitpod-Go-Debug](https://github.com/JesterOrNot/Gitpod-Go-Debug):
+To see a basic repository with Go debugging enabled, please check out [gitpod-io/Gitpod-Go-Debug](https://github.com/gitpod-io/Gitpod-Go-Debug):
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-Go-Debug)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Go-Debug)
 
 ## External Resources
 

--- a/src/docs/languages/html.md
+++ b/src/docs/languages/html.md
@@ -26,4 +26,4 @@ With Gitpod you can open a preview for Markdown and HTML files while you are cod
 
 Want to try it out? And see a minimal example in action? Great, then you can open this in Gitpod:
 
-[![JesterOrNot/Gitpod-Web-Development-Example](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-Web-Development-Example)
+[![gitpod-io/Gitpod-Web-Development-Example](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Web-Development-Example)

--- a/src/docs/languages/python.md
+++ b/src/docs/languages/python.md
@@ -11,7 +11,7 @@ Before we get started, here are some examples of already-[gitpodified](https://w
 | Repository                                                                                                |                                                                                                              Description |                                        Try it |
 -----------|-----------------------------------------------------------|----------------------------------------------------
 | [gitpod-io/django-locallibrary-tutorial](https://github.com/gitpod-io/django-locallibrary-tutorial) | An example website written in Django by MDN |        [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#gitpod-io/django-locallibrary-tutorial) |
-| [gitpod-io/Gitpod-PyQt](https://github.com/gitpod-io/Gitpod-PyQt)                               |    A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-PyQt) |
+| [gitpod-io/Gitpod-PyQt](https://github.com/gitpod-io/Gitpod-PyQt)                               |    A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-PyQt) |
 | [gitpod-io/wxPython-example](https://github.com/gitpod-io/wxPython-example)                      | A wxPython example for Gitpod    | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/wxPython-example) |
 | [techwithtim/Hangman](https://github.com/techwithtim/Hangman)                                       |   A wxPython example for Gitpod  |     [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/techwithtim/Hangman) |
 
@@ -106,7 +106,7 @@ Here are some other examples of Python GUI applications in Gitpod:
 |------------------|----------------|-----------|
 | Tic-Tac-Toe-GUI  | Kivy | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Tic-Tac-Toe-GUI) |
 | Pong             | Kivy | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Pong) |
-| Gitpod-PyQt | PyQt | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-PyQt) |
+| Gitpod-PyQt | PyQt | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-PyQt) |
 
 </div>
 

--- a/src/docs/languages/python.md
+++ b/src/docs/languages/python.md
@@ -11,7 +11,7 @@ Before we get started, here are some examples of already-[gitpodified](https://w
 | Repository                                                                                                |                                                                                                              Description |                                        Try it |
 -----------|-----------------------------------------------------------|----------------------------------------------------
 | [gitpod-io/django-locallibrary-tutorial](https://github.com/gitpod-io/django-locallibrary-tutorial) | An example website written in Django by MDN |        [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#gitpod-io/django-locallibrary-tutorial) |
-| [JesterOrNot/Gitpod-PyQt](https://github.com/JesterOrNot/Gitpod-PyQt)                               |    A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-PyQt) |
+| [gitpod-io/Gitpod-PyQt](https://github.com/gitpod-io/Gitpod-PyQt)                               |    A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-PyQt) |
 | [gitpod-io/wxPython-example](https://github.com/gitpod-io/wxPython-example)                      | A wxPython example for Gitpod    | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/wxPython-example) |
 | [techwithtim/Hangman](https://github.com/techwithtim/Hangman)                                       |   A wxPython example for Gitpod  |     [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/techwithtim/Hangman) |
 
@@ -146,9 +146,9 @@ Then, simply open the Python file you want to debug, open the Debug panel (in th
 <br>
 
 
-To see a basic repository with Python debugging enabled, please check out [JesterOrNot/Gitpod-Python-Debug](https://github.com/JesterOrNot/Gitpod-Python-Debug):
+To see a basic repository with Python debugging enabled, please check out [gitpod-io/Gitpod-Python-Debug](https://github.com/gitpod-io/Gitpod-Python-Debug):
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-Python-Debug)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Python-Debug)
 
 <br>
 

--- a/src/docs/languages/ruby.md
+++ b/src/docs/languages/ruby.md
@@ -40,4 +40,4 @@ vscode:
 
 So, you want to write your cool new Ruby On Rails application in Gitpod? Well, here is an idea of how to do it. Please take a look at our minimal Rails example running in Gitpod:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-Ruby-On-Rails)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Ruby-On-Rails)


### PR DESCRIPTION
Originally I kept all of these repositories on my personal account but to make the guide feel more official I changed the links to a gitpod-io org fork of the repositories. Also, I applied a few patches in regards to broken links.