### PR TITLE
[docs] Add link to @obasekietinosa's Laravel guide in Gitpod's PHP guide

### DIFF
--- a/src/docs/languages/php.md
+++ b/src/docs/languages/php.md
@@ -27,7 +27,6 @@ First, you must create a [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-
 ```Dockerfile
 FROM gitpod/workspace-full
 
-
 RUN sudo apt-get update -q \
     && sudo apt-get install -y php-dev
 
@@ -41,7 +40,7 @@ RUN wget http://xdebug.org/files/xdebug-2.9.1.tgz \
     && sudo bash -c "echo -e '\nzend_extension = /usr/lib/php/20170718/xdebug.so\n[XDebug]\nxdebug.remote_enable = 1\nxdebug.remote_autostart = 1\n' >> /etc/php/7.2/cli/php.ini"
 ```
 
-Second, reference the above Dockerfile in a [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) file, and then also install the extension, like so:
+Second, reference the above Dockerfile in a [.gitpod.yml](/docs/config-gitpod-file/) file, and then also install the extension, like so:
 
 ```yaml
 image:
@@ -81,6 +80,7 @@ Finally, here is a full [example repository](https://github.com/JesterOrNot/Gitp
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/Gitpod-PHP-Debug)
 
 ## PECL Package Manager
+
 Gitpod's default workspace image also comes with the [PECL](https://pecl.php.net/) package manager pre-installed. To install packages with it, you must use `sudo pecl install <EXTENSION>` in your repository's [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/), e.g. like so:
 ```Dockerfile
 FROM gitpod/workspace-full
@@ -89,3 +89,7 @@ RUN sudo pecl channel-update pecl.php.net && \
     sudo pecl install <EXTENSION>
 ``` 
 where `<EXTENSION>` is the PHP extension you want to install, e.g. `xdebug`.
+
+## External Resources
+
+- [Gitpodifying a new Laravel Application](https://notes.etin.space/posts/gitpodifying-a-new-laravel-application) by Etin Obaseki


### PR DESCRIPTION
@obasekietinosa wrote a fantastic step-by-step guide to Laravel in Gitpod:

https://notes.etin.space/posts/gitpodifying-a-new-laravel-application

I think we should add a link to it in Gitpod's PHP guide.

Many thanks Etin for powering through this, and for putting together very clear and helpful configuration steps! 💯