### PR TITLE
wrap: Example Repositories table in a div with the table container class

### DIFF
--- a/src/docs/languages/html.md
+++ b/src/docs/languages/html.md
@@ -6,11 +6,14 @@
 
 Here are a few HTML/CSS example projects that are already automated with Gitpod:
 
+<div class="table-container">
+
 Repository | Description | Try it
 ---|---|---
 [Front-End-Checklist](https://github.com/thedaviddias/Front-End-Checklist) | The perfect Front-End Checklist for modern websites and meticulous developers | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/thedaviddias/Front-End-Checklist)
 [Devhints](https://github.com/rstacruz/cheatsheets) | TL;DR for developer documentation - a ridiculous collection of cheatsheets | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rstacruz/cheatsheets)
 
+</div>
 ## [emmet](http://emmet.io/) Support
 
 ![emmet demo](../images/emmet.png)


### PR DESCRIPTION
Fixes gitpod-io/website#647

This is how it looks now:

![image](https://user-images.githubusercontent.com/46004116/82393521-1189c180-9a60-11ea-8d75-a19a99cf3dd0.png)
