### PR TITLE
Make it clear that some environment variables are reserved

### DIFF
--- a/src/docs/environment-variables.md
+++ b/src/docs/environment-variables.md
@@ -2,6 +2,15 @@
 
 You can pass environment variables into your workspace.
 
+## Default Environment Variables
+The following environment variables are set automatically by Gitpod and are guaranteed to exist:
+
+- `GITPOD_WORKSPACE_ID`: The Universally Unique Identifier (UUID) associated with the workspace.
+- `GITPOD_WORKSPACE_URL`: The unique URL of the workspace.
+
+### Reserved Prefix
+Environment variables beginning with the prefix  `GITPOD_` are reserved for internal use by Gitpod and are overridden on every workspace startup. This means that a _user-defined_ variable set with the name `GITPOD_FOOBAR` will be ignored and not accessible in the workspace.
+
 ## User-Specific Environment Variables
 Gitpod supports encrypted, user-specific environment variables.
 They are stored as part of your user settings and can be used to set access tokens, or pass any other kind of user-specific information to your workspaces.


### PR DESCRIPTION
It appears that user-defined variables beginning with the GITPOD_ prefix are discarded on workspace startup. This PR aims to document this behaviour.

Changes:
- Describes some of the default variables defined by Gitpod.
- Warns about defining new variables with the `GITPOD_` prefix.

Ideally the [Environment Variables](https://gitpod.io/environment-variables) page should disallow setting such variables since they will be ignored.

--
The wording could be improved (English is not my forte). Feedback is appreciated.