### PR TITLE
docs(LaTeX): use texlive instead of texlive-full

### DIFF
--- a/src/docs/languages/latex.md
+++ b/src/docs/languages/latex.md
@@ -11,7 +11,7 @@ FROM gitpod/workspace-full
 
 # Install LaTeX
 RUN sudo apt-get -q update && \
-    sudo apt-get install -yq texlive-full && \
+    sudo apt-get install -yq texlive && \
     sudo rm -rf /var/lib/apt/lists/*
 ```
 


### PR DESCRIPTION
apparently it's 10x smaller and does the same thing?

See https://github.com/gitpod-io/gitpod/issues/1561#issuecomment-635507762

Signed-off-by: Jacob Hrbek <kreyren@member.fsf.org>