### PR TITLE
Fix ugly line break in "Code Reviews"

### DIFF
--- a/src/docs/code-reviews.md
+++ b/src/docs/code-reviews.md
@@ -41,7 +41,7 @@ to GitHub.
 
 ![Gitpod Finish Review](images/cr-finish-review.png)
 
-If you have approved the PR, you can merge the changes by pushing the `Merge` button in the `Pull
-Request` view or conventionally on the GitHub website.
+If you have approved the PR, you can merge the changes by pushing the `Merge` button in the
+`Pull Request` view or conventionally on the GitHub website.
 
 ![Github Pull Request with Review Finished](images/cr-GitHub-pr-finished.png)


### PR DESCRIPTION
Newline character inside single quotes seems to be rendered verbatim, this produces an ugly line break in a very inappropriate place.