### PR TITLE
delayed: use gatsby-plugin-twitter for loading the tweets.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -82,6 +82,7 @@ module.exports = {
         'gatsby-transformer-sharp',
         'gatsby-plugin-react-helmet',
         'gatsby-plugin-catch-links',
+        `gatsby-plugin-twitter`,
         {
             resolve: 'gatsby-plugin-google-analytics',
             options: {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gatsby-plugin-react-helmet": "^3.3.2",
     "gatsby-plugin-sharp": "^2.6.9",
     "gatsby-plugin-sitemap": "^2.4.3",
+    "gatsby-plugin-twitter": "^2.3.10",
     "gatsby-plugin-typescript": "^2.4.3",
     "gatsby-remark-autolink-headers": "^2.3.3",
     "gatsby-remark-copy-linked-files": "^2.3.3",

--- a/src/components/index/Testimonials.tsx
+++ b/src/components/index/Testimonials.tsx
@@ -60,48 +60,47 @@ const StyledTestimonials = styled.div`
 
 `
 
-const twitterOptions = { theme: 'light', dnt: true, cards: 'hidden' };
+// const twitterOptions = { theme: 'light', dnt: true, cards: 'hidden' };
 
-const tweets = [
-    '1115274432958930946',
-    '1102215129696010240',
-    '1167463499779338243',
-    '1191710936605831169',
-    '1131239314346729482',
-    '1217728632887611397',
-    '1117695539540365312',
-    '1116152894548582402',
-    '1159698330764611584',
-    '1117141675745402881',
-    '1120015913024139265',
-    '1221093493214310400',
-    '1215700809104740354',
-]
+// const tweets = [
+//     '1115274432958930946',
+//     '1102215129696010240',
+//     '1167463499779338243',
+//     '1191710936605831169',
+//     '1131239314346729482',
+//     '1217728632887611397',
+//     '1117695539540365312',
+//     '1116152894548582402',
+//     '1159698330764611584',
+//     '1117141675745402881',
+//     '1120015913024139265',
+//     '1221093493214310400',
+//     '1215700809104740354',
+// ]
 
 const Testimonials: React.SFC<{}> = () => (
     <StyledTestimonials>
         <section className="testimonials">
-                <div className="row">
-                    <h2>Trusted by <strong>200,000+ Developers</strong></h2>
+            <div className="row">
+                <h2>Trusted by <strong>200,000+ Developers</strong></h2>
+            </div>
+            <div className="tweets">
+                <div className="tweet">
+                    <blockquote data-cards="hidden" className="tweet twitter-tweet"><p dir="ltr" lang="en">GitPod is incredibly cool.<br /><br />In my opinion, this is a big step in open source software contribution. I'm excited to see where we go from here.<a href="https://t.co/KUKJ507okI">https://t.co/KUKJ507okI</a></p>— Ben Halpern 🌱 (@bendhalpern) <a href="https://twitter.com/bendhalpern/status/1115274432958930946?ref_src=twsrc%5Etfw">April 8, 2019</a></blockquote>
                 </div>
-                <div className="tweets">
-                    {
-                        tweets.map(
-                            (t, i) =>
-                            <TweetEmbed
-                                key={i}
-                                className="tweet"
-                                id={t}
-                                options={twitterOptions}
-                            />
-                        )
-                    }
-                    <TweetEmbed
-                        className="tweet"
-                        id="1215707492740739072"
-                        options={{...twitterOptions, conversation: "none"}}
-                    />
+
+                <div className="tweet">
+                    <blockquote data-cards="hidden" className="tweet twitter-tweet"><p dir="ltr" lang="en">I've been playing around with the "next generation" of Cloud IDEs lately, and <a href="https://twitter.com/gitpodio?ref_src=twsrc%5Etfw">@gitpodio</a> is quickly emerging as one of the best 👨‍💻<br />Awesome <a href="https://twitter.com/github?ref_src=twsrc%5Etfw">@github</a> integration, slick Chrome extension, and super fast 🚀 <a href="https://t.co/WRmOwpD3Uu">https://t.co/WRmOwpD3Uu</a></p>— Hugh Durkin (@hughdurkin) <a href="https://twitter.com/hughdurkin/status/1102215129696010240?ref_src=twsrc%5Etfw">March 3, 2019</a></blockquote>
                 </div>
+
+                <div className="tweet">
+                    <blockquote data-cards="hidden" className="tweet twitter-tweet"><p dir="ltr" lang="en">Ya'all <a href="https://twitter.com/gitpod?ref_src=twsrc%5Etfw">@gitpod</a> is freaking amazing! We integrated it into our workflow for working on <a href="https://twitter.com/freeCodeCamp?ref_src=twsrc%5Etfw">@freeCodeCamp</a> 's codebase and I am honestly loving it. 🔥🔥!<br /><br />Go check it out on our repo <a href="https://t.co/tKCG49NUlF">https://t.co/tKCG49NUlF</a> now!</p>— Mrugesh Mohapatra (@raisedadead) <a href="https://twitter.com/raisedadead/status/1167463499779338243?ref_src=twsrc%5Etfw">August 30, 2019</a></blockquote>
+                </div>
+
+                <div className="tweet">
+                    <blockquote data-cards="hidden" className="tweet twitter-tweet"><p dir="ltr" lang="en">I think I’m in love with <a href="https://twitter.com/gitpod?ref_src=twsrc%5Etfw">@gitpod</a>. It’s such a powerful tool. I’ve learned so much in the past week just from stumbling across Github repos that interest me and appending “<a href="https://t.co/IkptsvEF3u">https://t.co/IkptsvEF3u</a>” to the URL. A+ tool all around.</p>— David Ressler (He/Him) (@DavidRessler) <a href="https://twitter.com/DavidRessler/status/1191710936605831169?ref_src=twsrc%5Etfw">November 5, 2019</a></blockquote>
+                </div>
+            </div>
         </section>
     </StyledTestimonials>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.10.3":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
@@ -7709,6 +7716,13 @@ gatsby-plugin-sitemap@^2.4.3:
     minimatch "^3.0.4"
     pify "^3.0.0"
     sitemap "^1.13.0"
+
+gatsby-plugin-twitter@^2.3.10:
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-twitter/-/gatsby-plugin-twitter-2.3.10.tgz#1605b39385c475b234eafc422019cb36a7a14648"
+  integrity sha512-WQzjGpeKCdxujzAWE2yFOKaI494J/Qb6vhDdLvtevOAZVXSaMdTSfwSSUr17jsu8TV5s47fasKox+h/0uRlJUw==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
 
 gatsby-plugin-typescript@^2.4.3:
   version "2.4.3"


### PR DESCRIPTION
I have tried to find a plugin which lets us fetch tweet embeds at build time but so far. I'm unable to do this so. The only difference that using `gatsby-plugin-twitter` has made is that the markup for the tweets is now server-rendered. The loading of the tweets is still terrible there is a lot of JS that twitter is shipping.

Tweets to me look like a non-interactive element. I wonder why they are shipping too much JS.
