### PR TITLE
Fixes gitpod-io/website#709

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -33,7 +33,7 @@ const StyledBlogPage = styled.div`
     .posts {
         display: flex;
         flex-wrap: wrap;
-        justify-content: space-between;
+        justify-content: space-around;
 
         @media (max-width: ${sizes.breakpoints.md}) {
             justify-content: space-around;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -33,7 +33,7 @@ const StyledBlogPage = styled.div`
     .posts {
         display: flex;
         flex-wrap: wrap;
-        justify-content: space-around;
+        justify-content: space-between;
 
         @media (max-width: 1140px) {
             justify-content: space-around;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -35,7 +35,7 @@ const StyledBlogPage = styled.div`
         flex-wrap: wrap;
         justify-content: space-around;
 
-        @media (max-width: ${sizes.breakpoints.md}) {
+        @media (max-width: 1140px) {
             justify-content: space-around;
         }
     }


### PR DESCRIPTION
Improve blog layout for small width screens by using `space-around` instead of `space-between` for the blog posts container