### PR TITLE
Added new version for gpsh

### DIFF
--- a/src/docs/self-hosted/0.5.0/admin/admin.md
+++ b/src/docs/self-hosted/0.5.0/admin/admin.md
@@ -1,0 +1,27 @@
+---
+url: /docs/self-hosted/0.5.0/admin/admin/
+---
+
+# Administrate Gitpod Self-Hosted
+
+While we are working on the administration experience, there is already a lot you can do if you know where to look.
+
+
+## Download a backup of a workspace
+
+Workpaces are stored as tar files in Minio or Google Storage buckets (depending on your configuration).
+The tar files can be downloaded from there and unpacked locally.
+
+
+## List all running workspaces
+
+`SELECT`....
+
+`kubectl get pods`
+
+## Stop a running workspace
+
+`kubectl delete pod`
+
+
+## Connect to built-in Registry

--- a/src/docs/self-hosted/0.5.0/install/database.md
+++ b/src/docs/self-hosted/0.5.0/install/database.md
@@ -1,0 +1,23 @@
+---
+url: /docs/self-hosted/0.5.0/install/database/
+---
+
+
+#### Database
+Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in. If you operate your own MySQL database (which we'd recommend in a production setting) you can use that one. You have the following options:
+
+* Integrated database: If not disabled, this MySQL database is installed in a Kubernetes pod as a part of Gitpod’s Helm chart.
+The database uses a Kubernetes PersistentVolume. We do not recommend using this option fo a production setting.
+
+* Own MySQL database: Gitpod requires MySQL in version 5.7 or newer.
+
+This chart installs a MySQL database which gets Gitpod up and running but is not suitable for production (the data is lost on each restart of the DB pod). To connect to a porper MySQL installation:
+   - initialize your MySQL database using the SQL files in `database/`. E.g. in a mysql session connected to your database server run:
+     ```
+     SET @gitpodDbPassword = IFNULL(@gitpodDbPassword, 'your-password-goes-here');
+     source database/01-create-user.sql;
+     source database/02-create-and-init-sessions-db.sql;
+     source database/03-recreate-gitpod-db.sql;
+     ```
+   - `echo values/database.yaml >> configuration.txt`
+   - in `values/database.yaml` change the values in `gitpod.db` to match your installation

--- a/src/docs/self-hosted/0.5.0/install/docker-registry.md
+++ b/src/docs/self-hosted/0.5.0/install/docker-registry.md
@@ -1,0 +1,32 @@
+---
+url: /docs/self-hosted/0.5.0/install/docker-registry/
+---
+
+# Docker Registry
+
+Gitpod builds Docker images during workspace startup. This enables custom Dockerfiles as part of your workspace config, but is also required for Gitpod itself to function.
+To this end, Gitpod requires a container registry where it can push the images it builds.
+
+By default Gitpod ships with a built-in Docker registry. If you operate your own Docker registry (which we'd recommend in a production setting) you can use that one. You have the following options:
+
+* Integrated docker registry: If not disabled, this docker registry is installed in a Kubernetes Pod as a dependency of Gitpod’s Helm chart.
+  The docker registry requires a Kubernetes PersistentVolume. This registry is not recommended to be used for production.
+* Own docker registry: Gitpod can connect to your own docker registry. Compared to its built-in counterpart this enables performance gains and access to otherwise private images.
+
+This helm chart can either deploy its own registry (default but requires [HTTPS certs](../https-certs/)) or use an existing one.
+To connect to an existing Docker registry, do the following steps:
+
+```
+echo values/registry.yaml >> configuration.txt
+```
+
+In `values/registry.yaml` replace `your.registry.com` with the name of your registry.
+
+Login to the registry and safe the authentication
+```
+docker --config secrets/ login your.registry.com && mv secrets/config.json secrets/registry-auth.json
+```
+
+Make sure the resulting JSON file contains the credentials (there should be an `auth` section containing them as base64 encoded string).
+
+If that's not the case you might have a credential store/helper set up (e.g. on macOS the _Securely store Docker logins in macOS keychain_ setting).

--- a/src/docs/self-hosted/0.5.0/install/domain.md
+++ b/src/docs/self-hosted/0.5.0/install/domain.md
@@ -1,0 +1,19 @@
+---
+url: /docs/self-hosted/0.5.0/install/domain/
+---
+
+# Domain
+
+Gitpod requires a domain resolvable by some nameserver (typically a public domain name, e.g. `your-domain.com`).
+As Gitpod launches services and workspaces on additional subdomains it also needs two wildcard domains.
+For example:
+
+    your-domain.com
+    *.your-domain.com
+    *.ws.your-domain.com
+
+Installing Gitpod on a subdomain works as well. For example:
+
+    gitpod.your-domain.com
+    *.gitpod.your-domain.com
+    *.ws.gitpod.your-domain.com

--- a/src/docs/self-hosted/0.5.0/install/helm-2x.md
+++ b/src/docs/self-hosted/0.5.0/install/helm-2x.md
@@ -1,0 +1,18 @@
+---
+url: /docs/self-hosted/0.5.0/install/helm-2x/
+---
+
+# Helm
+If you haven't done so before, install helm in the cluster:
+```
+kubectl create -f utils/helm-2-tiller-sa-crb.yaml
+helm init --service-account tiller
+```
+
+verify that helm was installed properly using `helm version`.
+```
+kubectl get nodes
+```
+```
+helm version
+```

--- a/src/docs/self-hosted/0.5.0/install/https-certs.md
+++ b/src/docs/self-hosted/0.5.0/install/https-certs.md
@@ -1,0 +1,66 @@
+---
+url: /docs/self-hosted/0.5.0/install/https-certs/
+---
+
+
+### HTTPS certificates
+
+
+While we highly recommend operating Gitpod using HTTPS, Gitpod is able to run on insecure HTTP.
+If you use Gitpod's inernal docker registry, the downside of not using HTTPS is that Kubernetes won't be able to pull images from the registry because it considers the registry insecure.
+You can either resort to using an [external registry](#docker-registry-optional) or use HTTPS. For running Gitpod on insecure HTTP, no HTTPS certificates are needed and you can skip this section.
+
+> Important: The HTTPS certificates for your domain must include `your-domain.com`, `*.your-domain.com` and `*.ws.your-domain.com`. Beware that wildcard certificates are valid for one level only (i.e. `*.a.com` is not valid for `c.b.a.com`).
+
+To use the HTTPS certificates for your domain
+ - `echo values/https.yaml >> configuration.txt`
+ - place your certificates in `secrets/https-certificates/` like so:
+```
+ secrets/https-certificates:
+  |- cert.pem
+  |- chain.pem
+  |- fullchain.pem
+  |- privkey.pem
+```
+
+Generate the [dhparams.pem](https://security.stackexchange.com/questions/94390/whats-the-purpose-of-dh-parameters) file using
+```
+openssl dhparam -out secrets/https-certificates/dhparams.pem 2048
+```
+
+#### Using Let's Encrypt
+
+The most accessible means of obtaining HTTPS certificates is using [Let's Encrypt](https://letsencrypt.org/) which provides free certificats to anybody who can prove ownership of a domain.
+Gitpod requires [wildcard certificates](https://en.wikipedia.org/wiki/Wildcard_certificate) (e.g. `*.ws.your-domain.com`) which [can be obtained via Let's Encrypt](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) but require [proof of ownership via DNS](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge).
+There is a [plethora of tutorials](https://www.google.com/search?q=letsencrypt+wildcard) how to [generate wildcard certificates](https://medium.com/@saurabh6790/generate-wildcard-ssl-certificate-using-lets-encrypt-certbot-273e432794d7) using Let's Encrypt.
+Things get considerably easier when your domain is registered with a service for which a [Certbot DNS plugin exists](https://certbot.eff.org/docs/using.html#dns-plugins).
+
+Asuming you have `certbot` installed, the following script will generate and configure the required certificates (notice the placeholders):
+```bash
+export DOMAIN=your-domain.cm
+export EMAIL=your@email.here
+export WORKDIR=/workspace/letsencrypt
+
+certbot certonly \
+    --config-dir $WORKDIR/config \
+    --work-dir $WORKDIR/work \
+    --logs-dir $WORKDIR/logs \
+    --manual \
+    --preferred-challenges=dns \
+    --email $EMAIL \
+    --server https://acme-v02.api.letsencrypt.org/directory \
+    --agree-tos \
+    -d *.ws.$DOMAIN \
+    -d *.$DOMAIN \
+    -d $DOMAIN
+
+# move them into place
+mkdir secrets/https-certificates
+find $WORKDIR/config/live -name "*.pem" -exec cp {} secrets/https-certificates \;
+
+# Generate dhparams
+openssl dhparam -out secrets/https-certificates/dhparams.pem 2048
+
+# Enable HTTPS
+echo values/https.yaml >> configuration.txt
+```

--- a/src/docs/self-hosted/0.5.0/install/install-on-gcp-manual.md
+++ b/src/docs/self-hosted/0.5.0/install/install-on-gcp-manual.md
@@ -1,0 +1,217 @@
+---
+url: /docs/self-hosted/0.5.0/install/install-on-gcp-manual/
+---
+
+# Manually Install Gitpod on Google Cloud Platform
+
+  > **TODO** This document is a stub only.
+
+## Before you begin
+ - install [gcloud cli](https://cloud.google.com/sdk/docs/#install_the_latest_cloud_tools_version_cloudsdk_current_version)
+   - `gcloud components install beta`
+ - setup Google cloud project
+ - choose a [zone and region](https://cloud.google.com/compute/docs/regions-zones/#available) to install your Gitpod cluster
+ - [Enable APIs](https://cloud.google.com/endpoints/docs/openapi/enable-api#enabling_an_api):
+   - Identity and Access Management (IAM)
+   - Cloud SQL Admin API
+
+```
+gcloud auth login
+gcloud config set core/project <gcloud-project>
+gcloud config set compute/region <gcloud-region>
+gcloud config set compute/zone <gcloud-zone>
+
+PROJECT_ID=<gcloud-project-id>
+REGION=<gcloud-region>
+```
+
+### IP
+
+```
+gcloud compute addresses create gitpod-inbound-ip --region=$REGION
+IP_ADDRESS=$(gcloud compute addresses describe gitpod-inbound-ip --region $REGION | grep "address:" | cut -d' ' -f2)
+```
+
+
+Now that you have a reserved IP address, you will have to set up the following DNS A records resolving to that IP address:
+  - `your-base-domain`
+  - `*.your-base-domain`
+  - `*.ws.your-base-domain`
+
+
+### VPC Network
+
+```
+gcloud compute networks create gitpod-vpc --bgp-routing-mode=regional --subnet-mode=auto
+```
+
+
+### Cluster
+
+```
+gcloud iam service-accounts create gitpod-nodes-meta
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/clouddebugger.agent
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/cloudtrace.agent
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/errorreporting.writer
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/logging.viewer
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/logging.logWriter
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/monitoring.metricWriter
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/monitoring.viewer
+
+gcloud iam service-accounts create gitpod-nodes-workspace
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/clouddebugger.agent
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/cloudtrace.agent
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/errorreporting.writer
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/logging.viewer
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/logging.logWriter
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/monitoring.metricWriter
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/monitoring.viewer
+```
+
+Choose one (or more) zones to install your cluster to
+```
+ZONES=us-west1-a,us-west1-b
+gcloud beta container clusters create gitpod-cluster \
+        --region=$REGION    \
+        --node-locations=$ZONES \
+        --cluster-version="1.13.7-gke.24" \
+        --addons=NetworkPolicy  \
+        \
+        --no-enable-basic-auth \
+        --no-issue-client-certificate \
+        \
+        --enable-ip-alias \
+        --cluster-ipv4-cidr="10.8.0.0/14" \
+        --services-ipv4-cidr="10.0.0.0/20" \
+        --network=gitpod-vpc \
+        \
+        --enable-network-policy \
+        --enable-pod-security-policy \
+        \
+        --metadata disable-legacy-endpoints=true \
+        --num-nodes=1 \
+        --enable-autoscaling --min-nodes=1 --max-nodes=3 \
+        --service-account=gitpod-nodes-meta@$PROJECT_ID.iam.gserviceaccount.com \
+        --node-labels="gitpod.io/workload_meta=true" \
+        --machine-type=n1-standard-4 \
+        --image-type=cos \
+        --disk-size=100 \
+        --disk-type=pd-ssd \
+        --enable-autorepair \
+        --local-ssd-count=0 \
+        --workload-metadata-from-node=SECURE
+
+gcloud beta container node-pools create workspace-pool-1 \
+        --region=$REGION    \
+        --cluster=gitpod-cluster \
+        \
+        --metadata disable-legacy-endpoints=true \
+        --num-nodes=0 \
+        --enable-autoscaling --min-nodes=0 --max-nodes=10 \
+        --service-account=gitpod-nodes-workspace@$PROJECT_ID.iam.gserviceaccount.com \
+        --node-labels="gitpod.io/workload_workspace=true" \
+        --machine-type=n1-standard-16 \
+        --image-type=ubuntu \
+        --disk-size=200 \
+        --disk-type=pd-ssd \
+        --enable-autorepair \
+        --local-ssd-count=1
+```
+
+## Optional
+
+### GCP Managed DB
+
+```
+DB_PW=$(openssl rand -base64 20)
+DB_NAME=gitpod-db
+BACKUP_TIME="04:00"
+gcloud sql instances create $DB_NAME \
+    --database-version MYSQL_5_7 \
+    --storage-size=100 \
+    --storage-auto-increase \
+    --tier=db-n1-standard-4 \
+    --region=$REGION \
+    --backup-start-time=$BACKUP_TIME \
+    --failover-replica-name=$DB_NAME-failover \
+    --replica-type=FAILOVER \
+    --enable-bin-log
+
+gcloud sql users set-password root --host % --instance $DB_NAME --password $DB_PW
+echo "Database root password: $DB_PW"
+```
+Note: Store password securely for later use!
+
+```
+gcloud iam service-accounts create gitpod-cloudsql-client
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-cloudsql-client@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/cloudsql.client
+gcloud iam service-accounts keys create gitpod-cloudsql-client-key.json --iam-account=gitpod-cloudsql-client@$PROJECT_ID.iam.gserviceaccount.com
+```
+
+
+#### Initialize DB
+
+ 1. [Get `cloud_sql_proxy` binary](https://cloud.google.com/sql/docs/mysql/sql-proxy#install)
+    ```
+    wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
+    chmod +x cloud_sql_proxy
+    ```
+
+ 2. Connect to DB
+    ```
+    ./cloud_sql_proxy -instances=$PROJECT_ID:$REGION:$DB_NAME=tcp:0.0.0.0:3306 -credential_file=./gitpod-cloudsql-client-key.json
+    ```
+
+    2nd terminal: login with root password
+    ```
+    mysql -u root -P 3306 -h 127.0.0.1 -p
+    ```
+
+ 3. Execute init scripts
+    Generate password for gitpod user:
+    ```
+    GITPOD_DB_PW=$(openssl rand -base64 20)
+    ```
+
+    ```
+    set @gitpodDbPassword = <GITPOD_DB_PW>;
+
+    source config/db/init/00-create-user.sql
+    source config/db/init/01-recreate-gitpod-db.sql
+    source config/db/init/02-create-and-init-sessions-db.sql
+    ```
+
+
+### GCP Buckets for workspace backups
+
+```
+gcloud iam service-accounts create gitpod-workspace-syncer
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-workspace-syncer@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/storage.admin
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-workspace-syncer@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/storage.objectAdmin
+gcloud iam service-accounts keys create gitpod-workspace-syncer-key.json --iam-account=gitpod-workspace-syncer@$PROJECT_ID.iam.gserviceaccount.com
+```
+
+
+### GCP Registry
+
+Push and Pull access to the registry
+```
+gcloud iam service-accounts create gitpod-registry-full
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:gitpod-registry-full@$PROJECT_ID.iam.gserviceaccount.com" --role=roles/storage.admin
+gcloud iam service-accounts keys create gitpod-registry-full-key.json --iam-account=gitpod-registry-full@$PROJECT_ID.iam.gserviceaccount.com
+```
+
+## Install
+
+cluster init:
+```
+kubectl create -f tiller-sa.yaml
+helm init --service-account tiller
+```
+
+install gitpod:
+```
+cd gitpod
+helm dependencies update
+helm install -f values.yaml [[-f <optional-values.yaml>]...] --name gitpod .
+```

--- a/src/docs/self-hosted/0.5.0/install/install-on-gcp-script.md
+++ b/src/docs/self-hosted/0.5.0/install/install-on-gcp-script.md
@@ -1,0 +1,39 @@
+---
+url: /docs/self-hosted/0.5.0/install/install-on-gcp-script/
+---
+
+# Install Gitpod on Google Cloud Platform
+
+Gitpod runs best on GCP. That's also where [gitpod.io](https://gitpod.io) is deployed and operated at scale.
+
+The easiest way to install Gitpod on GCP is by using our automated installation script. You can find it in this repository:
+
+  > https://github.com/gitpod-io/self-hosted/
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/self-hosted)
+
+This script will configure your GCP project, and produce the required Helm configuration to install Gitpod in that project.
+Once the setup is complete, you will simply need to set up [OAuth](../oauth/) and [HTTPS](../https-certs/).
+
+Alternatively, you can set up the GCP resources manually yourself. See the [manual GCP setup](../install-on-gcp-manual/) section for more details.
+
+## Prerequisites
+
+- A [Google Cloud](https://cloud.google.com/) project
+- A [Domain](../domain)
+- Optional: [HTTPS Certificates](../https-certs)
+
+
+Note that Google Cloud offers a [free trial](https://console.cloud.google.com/freetrial) with $300 worth of resources, which allows deploying and evaluating Gitpod Self-Hosted for free.
+
+## Configuration
+
+The [Gitpod Self-Hosted repository](https://github.com/gitpod-io/self-hosted) contains all the configuration files.
+
+In particular, you will want to configure your `values.yaml`, by setting up your domain and the [OAuth](../oauth/) section.
+
+## Installation
+
+To start the automated setup, simply run [`./utils/create-gcp-resources.go`](https://github.com/gitpod-io/self-hosted/blob/master/utils/create-gcp-resources.go) from the root of the `self-hosted` repository.
+
+The script will guide you through the process, and modify the relevant configuration files when needed. It will also ask for your confirmation before performing any changes or starting any service in GCP.

--- a/src/docs/self-hosted/0.5.0/install/install-on-kubernetes.md
+++ b/src/docs/self-hosted/0.5.0/install/install-on-kubernetes.md
@@ -1,0 +1,80 @@
+---
+url: /docs/self-hosted/0.5.0/install/install-on-kubernetes/
+---
+
+# Install Gitpod Self-Hosted on Kubernetes
+
+This section describes how to install Gitpod on a vanilla Kubernetes cluster.
+Gitpod also provides more optimized installations offering better performance for particular cloud providers:
+* *Google Cloud Platform*: Install Gitpod in a blank GCP project, either [using a script that automates the procedure](../install-on-gcp-script/) or [manually step-by-step](../install-on-gcp-manual/).
+
+## Prerequisites
+
+- A Kubernetes Cluster in Version 1.13 or newer.
+- [Domain](../domain)
+- [HTTPS Certificates](../https-certs): Optional, if you use an external docker registry.
+- `kubectl` with access to that cluster.
+- `helm`. We recommend version 3.x. Any version >= 2.11 will also work, but requires you to have [tiller configured](../helm-2x/).
+- Optional: A MySQL Database
+- Optional: A Docker Registry
+- Optional: Buckets Storage, e.g. Minio
+
+## Configuration
+
+The [Gitpod self-hosted repository](https://github.com/gitpod-io/self-hosted) contains the configuration files this guide is refering to.
+Throughout this guide you will be modifying the files found in this repo.
+We recommend you fork this repository so that you can easily rebase your changes on the latest version.
+
+```bash
+git clone https://github.com/gitpod-io/self-hosted
+cd self-hosted
+git remote rename origin upstream
+```
+
+For the rest of this guide we will assume that you are located in the root of a working copy of this repository.
+
+### Domain name and IP address
+Gitpod requires [domain names](../domain/) which resolve to the IP of your Kubernetes cluster. 
+Set your domain in the `values.yaml` under `gitpod.hostname`.
+
+By default Gitpod deploys a [`LoadBalancer` service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) as means of ingress.
+If you have a fixed IP address that you want to use, set the `gitpod.components.proxy.loadBalancerIP` field to the external IP of your cluster/load balancer.
+If this field is not set, Kubernetes will assign you a load balancer IP during deployment.
+Once you know your IP address, configure your three domain names to resolve to that IP address.
+
+### OAuth integration
+Gitpod delegates authentication to a configurable OAuth provider.
+
+Follow [the steps](../oauth/) to set up GitHub or GitLab as OAuth provider.
+
+### HTTPS certificates or external Docker registry
+Gitpod builds docker images on demand and runs them in Kubernetes pods as workspaces.
+Since Kubernetes by default only pulls images from secure Docker registries,
+you will either need to have [HTTPS certificates](../https-certs/) configured if you want to use the internal docker registry,
+or use an [external docker registry](../docker-registry/).
+
+## Recommended Configuration
+
+To get Gitpod running quickly, you may skip this chapter.
+For production scenarios, however, we highly recomend this configuration.
+
+* [**Docker Registry**](../docker-registry/): Use your own Docker registry instead of the built-in one.
+* [**HTTPS certificates**](../https-certs/): Configure HTTPS certificates for secure access to Gitpod.
+* [**Database**](../database/): Use your own MySQL database instead of the built-in one.
+
+## Installation
+
+```bash
+helm repo add charts.gitpod.io https://charts.gitpod.io
+helm dep update
+helm upgrade --install $(for i in $(cat configuration.txt); do echo -e "-f $i"; done) gitpod .
+```
+
+Visit `https://<your-domain.com>/` and check that you can login and start workspaces just like on gitpod.io.
+Launch a workpace. Launching the first workspace can take significantly longer (up to 15min), this is because Docker images are being pulled.
+
+## Customization
+
+* [**Storage**](../storage/): Configure where Gitpod stores stopped workspaces.
+* [**Kubernetes Nodes**](../nodes/): Configure file system layout and the workspace's node associativity.
+* [**Workspaces**](../workspaces/): Configure workspace sizing.

--- a/src/docs/self-hosted/0.5.0/install/nodes.md
+++ b/src/docs/self-hosted/0.5.0/install/nodes.md
@@ -1,0 +1,27 @@
+---
+url: /docs/self-hosted/0.5.0/install/nodes/
+---
+
+# Kubernetes Nodes
+
+Configure the nodes (computers or virtual machines) that Kuberntes runs Gitpod's workspace pods on.
+
+## Assign workload to Nodes
+Gitpod schedules two kinds of workloads: the Gitpod installation itself (which we refer to as _meta_) and the workspaces. Ideally both types of workloads run on seperate nodes to make makes scaling easier.
+Depending on your cluster size that may not be feasible though. Either way, you need two node labels in your cluster:
+- `gitpod.io/workload_meta=true` which marks the "meta" nodes and
+- `gitpod.io/workload_workspace=true ` which marks the workspace nodes.
+
+If you want to "mix 'n match", i.e. don't seperate the nodes you can simply run:
+```
+kubectl label node --all gitpod.io/workload_meta=true gitpod.io/workload_workspace=true
+```
+
+
+## Node Filesystem Layout
+Gitpod relies on the node's filesystem for making workspace content available, as well as for storing Theia. By default workspace data is placed in `/data` and Theia is copied to `/theia`. Depending on your node setup the root filesystem maybe **read-only** or **slow**.
+We recommend you change those two paths so that they're located on an SSD or some other form of fast local storage.
+
+To do this:
+   - `echo values/node-layout.yaml >> configuration.txt`
+   - in `values/node-layout.yaml` change the values to match your installation

--- a/src/docs/self-hosted/0.5.0/install/oauth.md
+++ b/src/docs/self-hosted/0.5.0/install/oauth.md
@@ -1,0 +1,43 @@
+---
+url: /docs/self-hosted/0.5.0/install/oauth/
+---
+
+# How To integrate Gitpod with OAuth providers
+
+Gitpod does not implement user authentication itself, but integrates with other auth provider using [OAuth2](https://oauth.net/2/).
+Usually your Git hosting solution (e.g. GitHub or GitLab) acts as the OAuth auth provider. This way we control access to Gitpod while at
+the same time making sure every user has proper access to their Git repository.
+
+Gitpod supports the following authentication providers:
+* github.com
+* GitHub Enterprise in version 2.16.x and higher
+* gitlab.com
+* GitLab Community Edition in version 11.7.x and higher
+* GitLab Enterprise Edition in version 11.7.x and higher
+* Bitbucket — coming soon
+* Custom Auth Provider – Inquiry TypeFox for a quote
+
+## GitHub
+To authenticate your users with GitHub you need to create a [GitHub OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
+Follow the guide linked above and:
+   - set "Authentication callback URL" to: 
+
+       
+    https://<your-domain.com>/auth/github/callback
+    
+ 
+   - copy the following values and configure them in `values.yaml`:
+      - `clientId`
+      - `clientSecret`
+
+## GitLab
+To authenticate your users with GitLab you need to create an [GitLab OAuth application](https://docs.gitlab.com/ee/integration/oauth_provider.html).
+Follow the guide linked above and:
+   - set "Authentication callback URL" to: 
+   
+    https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
+
+   - set "Scopes" to `api`, `read_user` and `read_repository`.
+   - copy the following values and configure them in `values.yaml`:
+      - `clientId` is the "Application ID" from the GitLab OAuth appication
+      - `clientSecret` is the "Secret" from the GitLab OAuth appication

--- a/src/docs/self-hosted/0.5.0/install/storage.md
+++ b/src/docs/self-hosted/0.5.0/install/storage.md
@@ -1,0 +1,19 @@
+---
+url: /docs/self-hosted/0.5.0/install/storage/
+---
+
+# Workspace Storage
+
+Gitpod uses bucket storage to persist the contents of workspaces. Each workspace is tarballed into a single archive file which is then uploaded to the bucket.
+
+By default Gitpod ships with [MinIO](https://min.io/) as built-in bucket storage. If you operate your own MinIO instance, or have access to Google Cloud Bucket storage you can use that one. You have the following options:
+
+* Integrated MinIO: If not disabled, Gitpod installs MinIO in Kubernetes as a dependency of Gitpod’s helm charts.
+  MinIO itself can serve as a [gateway](https://github.com/minio/minio/tree/master/docs/gateway) to other storage providers.
+  When storing the data itself, MinIO relies on a [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) which in turn supports a [wide range of storage backends](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes).
+* Bring your own storage bucket: Gitpod can be configured to connect to your own installation of MinIO or Google Cloud Storage compatible storage solution.
+
+This helm chart ships with a [MinIO](https://min.io/) installation for this purpose. 
+Alternatively, you can connect to your own [MinIO](https://min.io/) installation using
+ - `echo values/minio.yaml >> configuration.txt`
+ - in `values.minio.yaml` change the values to match your installation

--- a/src/docs/self-hosted/0.5.0/install/workspaces.md
+++ b/src/docs/self-hosted/0.5.0/install/workspaces.md
@@ -1,0 +1,12 @@
+---
+url: /docs/self-hosted/0.5.0/install/workspaces/
+---
+
+# Workspaces
+
+## Sizing
+
+Gitpod schedules workspaces as Kubernetes pods. Each workspace pod requests a certain amount of memory which directly affects how many workspaces are scheduled on a single node.
+If you want to change the default sizing (~ 8GiB per workspace) you should
+- `echo values.workspace-sizing.yaml >> configuration.txt`
+- adapt the values in `values.workspace-sizing.yaml` to match your installation.

--- a/src/docs/self-hosted/0.5.0/self-hosted.md
+++ b/src/docs/self-hosted/0.5.0/self-hosted.md
@@ -1,0 +1,29 @@
+---
+url: /docs/self-hosted/0.5.0/self-hosted/
+---
+
+
+# Gitpod Self-Hosted
+
+Gitpod, just as you know it from [gitpod.io](https://gitpod.io), can be deployed and operated on your own infrastructure. It supports different cloud providers, self-managed Kubernetes clusters, corporate firewalls, and even off-grid / air-gapped networks.
+
+
+## Installation
+
+You can find all configuration templates and installation scripts in this repository:
+
+  > https://github.com/gitpod-io/self-hosted/
+
+### Install on Google Cloud Platform
+
+The easiest way to install Gitpod Self-Hosted is currently on Google Cloud Platform (that's also where [gitpod.io](https://gitpod.io) is deployed). GCP is the recommended platform for most users:
+
+* [Install Gitpod on Google Cloud Platform](../install/install-on-gcp-script/)
+
+### Install on any Kubernetes cluster
+
+If you manage your own Kubernetes cluster, please follow this guide:
+
+* [Install Gitpod on self-managed Kubernetes](../install/install-on-kubernetes/)
+
+Note: Dedicated installation steps for AWS, Azure, and OpenShift are coming soon.


### PR DESCRIPTION
This PR copies the documentation of Gitpod Self-Hosted from [`src/docs/self-hosted/0.4.0`](https://github.com/gitpod-io/website/tree/master/src/docs/self-hosted/0.4.0) to `src/docs/self-hosted/0.5.0`.

This allows us to start editing the documentation for 0.5.0.

It is safe to merge this PR now, before the release, because 0.5.0 won't become visible on the public website unless we reconfigure the symlink [`src/docs/self-hosted/latest`](https://github.com/gitpod-io/website/tree/master/src/docs/self-hosted/) to point to the new version.