### PR TITLE
[docs] Move self-hosted documentation to gitpod-io/gitpod

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "gitpod"]
+	path = gitpod
+	url = https://github.com/gitpod-io/gitpod
+	branch = gpl/docs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "gitpod"]
 	path = gitpod
 	url = https://github.com/gitpod-io/gitpod
-	branch = gpl/docs
+	branch = master

--- a/src/docs/self-hosted/latest
+++ b/src/docs/self-hosted/latest
@@ -1,1 +1,1 @@
-0.5.0
+../../../gitpod/docs/self-hosted


### PR DESCRIPTION
*Note*: This depends on https://github.com/gitpod-io/gitpod/pull/1757 being merged.

Fixes https://github.com/gitpod-io/gitpod/issues/1750.

This:
 - adds gitpod-io/gitpod:master as a submodule as top-level 'folder' `gitpod`
 - points `src/docs/self-hosted/latest` to `gitpod/docs/self-hosted` (cmp. [gitpod-io/gitpod PR](https://github.com/gitpod-io/gitpod/pull/1757))

I maintained the current link structure under `/self-hosted/**` to a) maintain current links b) get this working quickly.