### PR TITLE
[gitpod-vs-codespaces] Minor tweaks

### DIFF
--- a/src/components/gitpod-vs-codespaces/SpeedComparison.tsx
+++ b/src/components/gitpod-vs-codespaces/SpeedComparison.tsx
@@ -35,7 +35,7 @@ const StyledSpeedComparison = styled.div`
     }
 
     .footnote {
-        bottom: -5rem;
+        bottom: -3rem;
     }
   }
 
@@ -138,16 +138,14 @@ const SpeedComparison = () => (
   <StyledSpeedComparison>
     <div className="mark mark--2">
       <div className="mark__title footnote">
-        Open
-        <br />
-        Project
+        Click
       </div>
       <div className="item item--1">
         <h4>Gitpod</h4>
         <div className="bar-container">
           <div className="bar bar--gitpod">
-            <div className="bar--gitpod-1"></div>
-            <div className="bar--gitpod-2 bar--time">&lt;1 min</div>
+            <div className="bar--gitpod-1" title="Boot Environment & Load UI (< 1 min)"></div>
+            <div className="bar--gitpod-2 bar--time">&lt; 1 min</div>
           </div>
         </div>
       </div>
@@ -155,8 +153,8 @@ const SpeedComparison = () => (
         <h4>Codespaces</h4>
         <div className="bar-container">
           <div className="bar bar--codespaces">
-            <div className="bar--codespaces-1">Loading</div>
-            <div className="bar--codespaces-2">Project Build</div>
+            <div className="bar--codespaces-1" title="Boot Environment & Load UI (> 5 min)">Load</div>
+            <div className="bar--codespaces-2" title="Build Project (> 10 min)">Build Project</div>
             <div className="bar--codespaces-3 bar--time">&gt; 15 min</div>
           </div>
         </div>

--- a/src/contents/gitpod-vs-codespaces.tsx
+++ b/src/contents/gitpod-vs-codespaces.tsx
@@ -8,7 +8,7 @@ import { Link } from 'gatsby'
 export const features: FeatureCardProps[] = [
   {
     id: 'fast',
-    title: <strong>Loads 15x Faster</strong>,
+    title: <strong>15x Faster Loading</strong>,
     text: (
       <>
         <p>
@@ -24,7 +24,7 @@ export const features: FeatureCardProps[] = [
       </>
     ),
     Figure: SpeedComparison,
-    figFootnote: 'Compared start up time until ready-to-code of https://github.com/microsoft/vscode. Last verified Sept 25, 2020.'
+    figFootnote: 'Compared start-up time until ready-to-code for https://github.com/microsoft/vscode. Last verified 25 Sep 2020.'
   },
   {
     id: 'resource-efficient',
@@ -41,8 +41,8 @@ export const features: FeatureCardProps[] = [
       </>
     ),
     Figure: PowerComparison,
-    figFootnote: <>Compared hardware specs $9/month using 100 active hours. Last verified Sept 25, 2020. Sources: <Link to="/pricing">Gitpod Pricing</Link>, <a href=
-    "https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/about-billing-for-codespaces" target="_blank">Codespaces Pricing.</a></>,
+    figFootnote: <>Compared resources for 100 active hours at $9/month. Last verified 25 Sep 2020. Sources: <Link to="/pricing/">Gitpod Pricing</Link>, <a href=
+    "https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/about-billing-for-codespaces" target="_blank">Codespaces Pricing</a>.</>,
   },
   {
     id: 'open-source',


### PR DESCRIPTION
Looking at the new page (excellent work!) I wanted to suggest a few minor tweaks in order to slightly clarify the content:

- Title: "Loads 15x Faster" --> "15x Faster Loading"
- Graphic: "Open Project" --> "Click"
- Graphic: Turned loading phases into verbs (because they're actions), and added clarifying tooltips with sub-times
- Slightly improved the graph's footnotes

@ChristinFrohne @nisarhassan12 any thoughts/concerns? 😇