### PR TITLE
Correct typo in OAuth guide

### DIFF
--- a/src/docs/self-hosted/0.3.0/install/oauth.md
+++ b/src/docs/self-hosted/0.3.0/install/oauth.md
@@ -28,5 +28,5 @@ Follow the guide linked above and:
 
    - set "Scopes" to `api`, `read_user` and `read_repository`.
    - copy the following values and configure them in `values.yaml`:
-      - `clientId` is the "Application ID" from the GitLab OAuth appication
-      - `clientSecret` is the "Secret" from the GitLab OAuth appication
+      - `clientId` is the "Application ID" from the GitLab OAuth application
+      - `clientSecret` is the "Secret" from the GitLab OAuth application

--- a/src/docs/self-hosted/0.4.0/install/oauth.md
+++ b/src/docs/self-hosted/0.4.0/install/oauth.md
@@ -39,5 +39,5 @@ Follow the guide linked above and:
 
    - set "Scopes" to `api`, `read_user` and `read_repository`.
    - copy the following values and configure them in `values.yaml`:
-      - `clientId` is the "Application ID" from the GitLab OAuth appication
-      - `clientSecret` is the "Secret" from the GitLab OAuth appication
+      - `clientId` is the "Application ID" from the GitLab OAuth application
+      - `clientSecret` is the "Secret" from the GitLab OAuth application

--- a/src/docs/self-hosted/0.5.0/install/oauth.md
+++ b/src/docs/self-hosted/0.5.0/install/oauth.md
@@ -39,5 +39,5 @@ Follow the guide linked above and:
 
    - set "Scopes" to `api`, `read_user` and `read_repository`.
    - copy the following values and configure them in `values.yaml`:
-      - `clientId` is the "Application ID" from the GitLab OAuth appication
-      - `clientSecret` is the "Secret" from the GitLab OAuth appication
+      - `clientId` is the "Application ID" from the GitLab OAuth application
+      - `clientSecret` is the "Secret" from the GitLab OAuth application


### PR DESCRIPTION
Replaces two occurrences of `appication` with `application` in the GitPod OAuth guide.