### PR TITLE
Add feature preview docs and a note about custom IDE images

### DIFF
--- a/src/docs/feature-preview.md
+++ b/src/docs/feature-preview.md
@@ -18,7 +18,7 @@ This feature also enables Docker in your workspace. Run `sudo docker-up` to star
 
 Gitpod uses Theia as the default IDE. This setting allows you to choose between [Theia](https://github.com/eclipse-theia/theia) and [Code](https://github.com/microsoft/vscode) editors.
 
-You can choose between 3 options:
+You can choose between 2 options:
 
 - Theia
 - Code

--- a/src/docs/feature-preview.md
+++ b/src/docs/feature-preview.md
@@ -1,6 +1,6 @@
 # Feature Preview
 
-You can enable Feature Preview from the Settings. This will enable a beta preview of some of the latest functionalities and features that are being actively developed. Some of them are user-facing features while others take place in the backstage.
+You can enable Feature Preview from the [Settings](https://gitpod.io/settings/). This will enable a beta preview of some of the latest functionalities and features that are being actively developed. Some of them are user-facing features while others take place in the backstage.
 
 You can disable Feature Preview at any time.
 
@@ -16,10 +16,11 @@ This feature also enables Docker in your workspace. Run `sudo docker-up` to star
 
 ## Default IDE
 
-Gitpod uses Theia as the default IDE. This setting allows you to choose between [Theia](https://github.com/eclipse-theia/theia) and [Code](https://github.com/microsoft/vscode) editors as well as provide a custom IDE image.
+Gitpod uses Theia as the default IDE. This setting allows you to choose between [Theia](https://github.com/eclipse-theia/theia) and [Code](https://github.com/microsoft/vscode) editors.
 
 You can choose between 3 options:
 
 - Theia
 - Code
-- Image
+
+> There's also a private beta for allowing a custom IDE image for the default IDE. If you are interested, feel free to reach out through the [contact form](https://www.gitpod.io/contact/).

--- a/src/docs/feature-preview.md
+++ b/src/docs/feature-preview.md
@@ -1,0 +1,25 @@
+# Feature Preview
+
+You can enable Feature Preview from the Settings. This will enable a beta preview of some of the latest functionalities and features that are being actively developed. Some of them are user-facing features while others take place in the backstage.
+
+You can disable Feature Preview at any time.
+
+If you have suggestions on how we can improve a feature, please provide feedback by [opening an issue](https://github.com/gitpod-io/gitpod/issues/new/choose).
+
+> Once you enable this, existing and new workspaces will automatically start with all beta features. Disabling this could make existing workspaces unstable. 
+
+## Root Access
+
+Root Access allows you to attain privileged control within a workspace and be able to run commands as root.
+
+This feature also enables Docker in your workspace. Run `sudo docker-up` to start a Docker daemon.
+
+## Default IDE
+
+Gitpod uses Theia as the default IDE. This setting allows you to choose between [Theia](https://github.com/eclipse-theia/theia) and [Code](https://github.com/microsoft/vscode) editors as well as provide a custom IDE image.
+
+You can choose between 3 options:
+
+- Theia
+- Code
+- Image

--- a/src/docs/menu.ts
+++ b/src/docs/menu.ts
@@ -108,6 +108,10 @@ export const MENU: MenuEntry[] = [
         ]
     ),
     M(
+        "Feature Preview",
+        "feature-preview",
+    ),
+    M(
         "Gitpod Self-Hosted",
         "self-hosted/latest/self-hosted",
         [


### PR DESCRIPTION
This will re-introduce the **Feature Preview** docs originally added in https://github.com/gitpod-io/website/pull/846.

We should merge this to master as soon as the new release has been deployed on gitpod.io.

See also [relevant discussion](https://typefox.slack.com/archives/C01ELAYHVNH/p1606727350001100) (internal).

/cc @csweichel @svenefftinge 