### PR TITLE
[Netlify] Disable tracking in contact form submission emails

### DIFF
--- a/src/functions/submit-form.ts
+++ b/src/functions/submit-form.ts
@@ -28,7 +28,16 @@ async function sendEmail(client: client.MailService, email: Email): Promise<{sta
                 type: "text/plain",
                 value: `${email.message ? email.message : `${email.feedback}\n${email.otherFeedback}`}`
             }
-        ]
+        ],
+        tracking_settings: {
+            click_tracking: {
+                enable: false,
+                enable_text: false
+            },
+            open_tracking: {
+                enable: false
+            }
+        }
     }
     try {
         await client.send(data);


### PR DESCRIPTION
Currently, we receive contact form emails with a bunch of SendGrid query parameters in the URLs (e.g. `?utm_campaign=sendgrid-emails&utm_source=sendgrid&utm_medium=automated_emails`).

This isn't nice, so I propose to disable the tracking on contact form submission emails.

- `tracking_settings` spec: https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html#-Request-Body-Parameters

### How to test

1. Send a contact email containing a URL via https://deploy-preview-853--gitpod-website.netlify.app/contact/

2. The received email should **not** have a bunch of extra UTM parameters in the URL.