### PR TITLE
Update header navigation

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -277,28 +277,11 @@ const Nav = () => {
 
                     <ul className={`nav__items ${isNavRendered ? 'navIsRendered' : 'navIsNotRendered'}`} >
                         <li className="nav__item"><Link activeClassName="active" to='/features/' className="link">Features</Link></li>
-                        <li className="nav__item"><Link activeClassName="active" to='/self-hosted/' className="link">Self-Hosted</Link></li>
+                        <li className="nav__item"><Link activeClassName="active" to='/self-hosted/' className="link">Install</Link></li>
                         <li className="nav__item"><Link activeClassName="active" to='/pricing/' className="link">Pricing</Link></li>
-                        <li className="nav__item">
-                            <DropDown
-                                title="Resources"
-                                links={[
-                                    {
-                                        text: 'Docs',
-                                        to: '/docs/'
-                                    },
-                                    {
-                                        text: 'Blog',
-                                        to: '/blog/'
-                                    },
-                                    {
-                                        text: 'Community',
-                                        to: 'https://community.gitpod.io/',
-                                        target: true
-                                    }
-                                ]}
-                            />
-                        </li>
+                        <li className="nav__item"><Link activeClassName="active" to='/docs/' className="link">Docs</Link></li>
+                        <li className="nav__item"><Link activeClassName="active" to='/blog/' className="link">Blog</Link></li>
+                        <li className="nav__item"><Link activeClassName="active" to='https://community.gitpod.io/' target='true' className="link">Community</Link></li>
                         <li className="nav__item"><a href="https://gitpod.io/login/" rel="noopener" className="btn btn--small">Log In</a></li>
                     </ul>
 


### PR DESCRIPTION
This will update the top navigation for `www.gitpod.io` and `docs.gitpod.io`.
1. Surface the hidden links _Docs_, _Blog_, _Community_ from the previously _Resources_ menu item.
1. Rename _Self-hosted_ to _Install_.

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/101155648-185cd800-3630-11eb-8043-5ae255a5937a.png) | ![image](https://user-images.githubusercontent.com/120486/101155680-21e64000-3630-11eb-9585-5b4cb60d793d.png) |