### PR TITLE
update meta descriptions for /blog and /docs for better SEO.

### DIFF
--- a/src/layouts/docs.tsx
+++ b/src/layouts/docs.tsx
@@ -125,7 +125,7 @@ interface DocsLayoutProps {
 }
 
 const DocsLayout: React.SFC<DocsLayoutProps> = ({ canonical, title, body}) => (
-    <IndexLayout canonical={canonical} title={title} description="Documentation site for Gitpod.">
+    <IndexLayout canonical={canonical} title={title} description="Explore the documentation to learn more about Gitpod.io and Gitpod Self-Hosted.">
         <StyledDocsLayout>
                 <div className="row">
                     <div className="content">

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -97,7 +97,7 @@ const BlogPage: React.SFC<BlogPageProps> = (props) => {
         Date.parse(b.node.frontmatter.date) - Date.parse(a.node.frontmatter.date));
 
     return (
-        <IndexLayout canonical="/blog/" title="Blog" description="Discover articles and tutorials about Gitpod.">
+        <IndexLayout canonical="/blog/" title="Blog" description="Visit the Gitpod blog to learn about releases, tutorials, news and more.">
             <StyledBlogPage>
 
                 {/* ----- Section Posts ----- */}


### PR DESCRIPTION
Addresses the following parts of #842 

![image](https://user-images.githubusercontent.com/46004116/101197491-fc832180-3683-11eb-9bf6-89d6282ffded.png)
