### PR TITLE
Add link to Gitpod vs GitHub Codespaces Landing Page in the footer.

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -111,6 +111,7 @@ const Footer: React.SFC<{}> = () => (
                     <li><Link to="/pricing/">Pricing</Link></li>
                     <li><Link to="/blog/">Blog</Link></li>
                     <li><Link to="/self-hosted/">Self-Hosted</Link></li>
+                    <li><Link to="/gitpod-vs-github-codespaces">Gitpod vs GitHub <br />Codespaces</Link></li>
                     <li><a href="https://gitpod.io/login/" style={{ color: colors.link, fontWeight: 600 }}>Log In</a></li>
                 </ul>
                 <ul>


### PR DESCRIPTION
Fixes gitpod-io/website#883

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/101645690-79354780-3a58-11eb-9f9d-4888f155fa82.png)
