### PR TITLE
Add getting started button

### DIFF
--- a/src/components/index/Banner.tsx
+++ b/src/components/index/Banner.tsx
@@ -94,6 +94,9 @@ const Banner = () => (
                 <a href="#get-started" className="btn btn--cta">
                   Try Now
                 </a>
+                <a href="https://www.gitpod.io/docs/getting-started/" className="btn" style={{ marginLeft: '8px' }}>
+                    Getting Started
+                </a>
                 <p className="works-with">
                   Works with
                   <img src={GitLab} alt="GitLab" />


### PR DESCRIPTION
This will add a secondary button to link to the new [Getting Started](https://www.gitpod.io/docs/getting-started/) section in the docs which mentions how you can use Gitpod.

**Context**: This builds on top of the original proposal in https://github.com/gitpod-io/website/issues/882#issue-759375835 and moves us one step closer to https://github.com/gitpod-io/website/issues/876.

| BEFORE | AFTER |
|-|-|
| ![image](https://user-images.githubusercontent.com/120486/102494020-b747f200-407c-11eb-991b-4974cc784631.png) | ![image](https://user-images.githubusercontent.com/120486/102494037-bdd66980-407c-11eb-91dc-92a5ad42b588.png) |

