### PR TITLE
align the spacing in the footer.

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,8 +12,16 @@ const StyledFooter = styled.footer`
 
     .links {
         display: flex;
-        justify-content: space-around;
+        justify-content: space-between;
         flex-wrap: wrap;
+        max-width: 1000px;
+        margin: 0 auto;
+
+        @media(min-width: 651px) {
+            ul {
+                width: 12.4rem;
+            }
+        }
 
         @media(max-width: 650px) {
             justify-content: space-between;


### PR DESCRIPTION
Fixes gitpod-io/website#908

I have made the size constant for all the links sets on larger devices this is how the footer looks now:

![image](https://user-images.githubusercontent.com/46004116/103155161-cb979780-47be-11eb-98a4-02e149c097ab.png)

This is how it looked before:

![image](https://user-images.githubusercontent.com/46004116/103155168-dbaf7700-47be-11eb-93fc-ad3f461fda37.png)


