### PR TITLE
Change ambiguous text that implies Gitpod is fully open source

### DIFF
--- a/src/components/index/SecurityAndOSS.tsx
+++ b/src/components/index/SecurityAndOSS.tsx
@@ -49,12 +49,12 @@ const SecurityAndOSS = () => (
         <TextFeature
           path={OpenSourceImg}
           alt="Open Source"
-          title="Free For Open-Source!"
+          title="No Cost to Open-Source Projects!"
           text={
             <>
               <p>
-                Gitpod is built on open-source and wouldn’t exist without it. We’re happy to give something back by being completely{' '}
-                <strong>free for open source.</strong>
+                Gitpod is built on open-source and wouldn’t exist without it. We’re happy to give something back by providing {' '}
+                <strong>a no-cost license for open source projects.</strong>
               </p>
               <p>Do you want to contribute to a new project? Here is a list of all prebuilt open-source projects.</p>
             </>


### PR DESCRIPTION
I was very excited to discover Gitpod. It was very easy to set up a contribution environment for my Django website.

On the Gitpod website, there is this text: "Free For Open-Source! Gitpod is built on open-source and wouldn’t exist without it. We’re happy to give something back by being completely free for open source."

I assumed when I read this text that Gitpod was completely open source. I think it's because I'm used to reading "free and open source software" (FOSS). My quick read mistook the phrase "free **for** open source" as "free **and** open source". I'm used to people saying this project is "completely free and open source".

I was disappointed when I discovered that Gitpod was not fully open source. It's built on MIT and AGPL code, but it includes proprietary code licensed under the [Gitpod Self-Hosted Free License Terms and Gitpod Enterprise Source Code License](https://github.com/gitpod-io/gitpod/blob/master/License.enterprise.txt). Specifically, that license restricts what people can do with the modified code, to forbid commercial use cases.

I sympathize with wanting to ensure that you're paid for the code you've created! I appreciate you using open source. However, other people in the open source community could also be mislead by this ambiguous wording. It's best to be up front that Gitpod is proprietary code, and set people's expectations correctly.

I propose changing the text to make it clear that Gitpod is giving a no-cost ("free") license for people to use Gitpod in conjunction with open source projects. I'm happy to discuss alternative wording.