### PR TITLE
[docs]: categorize frameworks in submenus under their relevant language 

### DIFF
--- a/src/components/Linkset.tsx
+++ b/src/components/Linkset.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import { colors } from '../styles/variables'
 import { Link } from 'gatsby'
 
-const StyledLinkSet = styled.div`
+const StyledLinkSet = styled.ul`
 
     &:not(:last-child) {
         margin-bottom: 2rem;
@@ -43,16 +43,17 @@ const StyledLinkSet = styled.div`
 interface LinkSetProps {
     caption: string
     path: string
+    className?: string
 }
 
 class Linkset extends React.Component<LinkSetProps, {}> {
 
     render() {
 
-        const { caption, path, children } = this.props
+        const { caption, path, children, className } = this.props
 
         return (
-            <StyledLinkSet>
+            <StyledLinkSet className={className}>
                 <li>
                     <Link
                         to={path}

--- a/src/components/docs/DocSideBar.tsx
+++ b/src/components/docs/DocSideBar.tsx
@@ -58,18 +58,83 @@ const StyledSideBar = styled.div`
     @media(max-width: ${sizes.breakpoints.lg}) {
         display: none;
     }
+
+    li {
+        ul {
+            margin: 1.5rem 0 1.5rem 1rem;
+        }
+    }
+
+    .linkset {
+        &--small {
+            a.caption { 
+                font-size: 1.5rem;
+                font-weight: 600;
+                margin-bottom: .2rem;
+            }
+        }
+    }
+
+    .link {
+        &--small {
+            font-size: 1.4rem;
+            margin-left: 1rem;
+        }
+    }
 `
 
 const DocSideBar: React.SFC<{}> = () => (
     <StyledSideBar>
         <ul>
             <Docsearch name="search-doc-input" />
-            {MENU.map((m, i) =>
-                <Linkset caption={m.title} path={m.path} key={'menu' + i}>
-                    {m.subMenu && m.subMenu.map((sub, i) =>
-                        <li><Link activeClassName='active' to={sub.path} key={'sub' + i}>{sub.title}</Link></li>
-                    )}
-                </Linkset>)}
+            {
+                MENU.map((m, i) => {
+                    console.log(m)
+                    return (
+                        <Linkset caption={m.title} path={m.path} key={'menu' + i}>
+                            {
+                                m.subMenu &&
+                                m.subMenu.map((sub, i) =>
+                                    <li>
+                                        {
+                                            sub.subMenu ? (
+                                                <Linkset
+                                                    caption={sub.title}
+                                                    path={sub.path}
+                                                    key={'sub' + i}
+                                                    className="linkset--small"
+                                                >
+                                                    {
+                                                        sub.subMenu.map((y, i) => (
+                                                            <li>
+                                                                <Link
+                                                                    activeClassName='active'
+                                                                    to={y.path}
+                                                                    key={'y' + i}
+                                                                    className="link--small"
+                                                                >
+                                                                    {y.title}
+                                                                </Link>
+                                                            </li>
+                                                        ))
+                                                    }
+                                                </Linkset>
+                                            ) : (
+                                                    <Link
+                                                        activeClassName='active'
+                                                        to={sub.path}
+                                                        key={'sub' + i}
+                                                    >
+                                                        {sub.title}
+                                                    </Link>
+                                                )
+                                        }
+                                    </li>
+                                )}
+                        </Linkset>
+                    )
+                }
+                )}
         </ul>
     </StyledSideBar>
 )

--- a/src/components/docs/DocTopicChooser.tsx
+++ b/src/components/docs/DocTopicChooser.tsx
@@ -35,10 +35,32 @@ const DocTopicChooser: React.SFC<{}> = () => {
                 <option value='#' selected={true}>Select A Topic</option>
                 {MENU.map(m => {
                     return <>
-                        <option key={m.path} value={m.path}>{m.title}</option>
+                        <option
+                            key={m.path}
+                            value={m.path}
+                        >
+                            {m.title}
+                        </option>
                         {
                             (m.subMenu || []).map(m =>
-                                <option key={m.path} value={m.path}>&nbsp;&nbsp;&nbsp;&nbsp;{m.title}</option>
+                                <>
+                                    <option
+                                        key={m.path}
+                                        value={m.path}
+                                    >
+                                        &nbsp;&nbsp;&nbsp;&nbsp;{m.title}
+                                    </option>
+                                    {
+                                        (m.subMenu || []).map(sub => (
+                                            <option
+                                                key={sub.path}
+                                                value={sub.path}
+                                            >
+                                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{sub.title}
+                                            </option>
+                                        ))
+                                    }
+                                </>
                             )
                         }
                     </>

--- a/src/docs/menu.ts
+++ b/src/docs/menu.ts
@@ -167,11 +167,27 @@ export const MENU: MenuEntry[] = [
         [
             M(
                 "JavaScript",
-                "languages/javascript"
+                "languages/javascript",
+                [
+                    M(
+                        "Vue",
+                        "languages/vue"
+                    ),
+                    M(
+                    "Svelte",
+                    "languages/svelte"
+                    ),
+                ]
             ),
             M(
                 "Python",
-                "languages/python"
+                "languages/python",
+                [
+                    M(
+                        "Pandas",
+                        "languages/python/#pandas"
+                    ),
+                ]
             ),
             M(
                 "HTML/CSS",
@@ -179,7 +195,13 @@ export const MENU: MenuEntry[] = [
             ),
             M(
                 "Java",
-                "languages/java"
+                "languages/java",
+                [
+                    M(
+                        "Kotlin",
+                        "languages/kotlin"
+                    ),
+                ]
             ),
             M(
                 "C++",
@@ -200,14 +222,6 @@ export const MENU: MenuEntry[] = [
             M(
                 "PHP",
                 "languages/php"
-            ),
-            M(
-                "Vue",
-                "languages/vue"
-            ),
-            M(
-                "Svelte",
-                "languages/svelte"
             ),
             M(
                 "Scala",
@@ -237,14 +251,6 @@ export const MENU: MenuEntry[] = [
             M(
                 "R",
                 "languages/r"
-            ),
-            M(
-                "Kotlin",
-                "languages/kotlin"
-            ),
-            M(
-                "Pandas",
-                "languages/python/#pandas"
             ),
             M(
                 "Deno",


### PR DESCRIPTION
Fixes gitpod-io/website#783

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/103343856-e021ab80-4aae-11eb-940c-44f6012743e0.png)


