### PR TITLE
[pricing]: make the z-index for the buttons lower than that of the cookie consent.

### DIFF
--- a/src/components/PricingBox.tsx
+++ b/src/components/PricingBox.tsx
@@ -155,7 +155,7 @@ const StyledPricingBox = styled.div<StyledPricingBoxProps>`
         flex-direction: column;
         justify-content: space-between;
         align-items: center;
-        z-index: 1999999999;
+        z-index: 9;
 
         @media(min-width: calc(${sizes.breakpoints.sm} + 1px)) {
             position: absolute;

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -99,7 +99,7 @@ class IndexLayout extends React.Component<{ title?: string; canonical?: string; 
                   backgroundColor: colors.white,
                   color: colors.text,
                   borderTop: borders.light,
-                  zIndex: '1000000000'
+                  zIndex: '2000000000'
                 }}
                 contentStyle={{
                   backgroundColor: 'transparent',


### PR DESCRIPTION
Fixes gitpod-io/website#818

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/103371895-67dcd980-4af2-11eb-8ab4-39debffd8a93.png)

