### PR TITLE
Add tip about preventing accidental close of the editor

### DIFF
--- a/src/docs/tips-and-tricks.md
+++ b/src/docs/tips-and-tricks.md
@@ -6,7 +6,7 @@
   * [Search in Workspace](#search-in-workspace)
   * [Symbols and References](#symbols-and-references)
   * [Format Document](#format-document)
-  * [Prevent accidental close](#prevent-accidental-close)
+  * [Prevent Accidental Close](#prevent-accidental-close)
 
 ## Command Palette
 
@@ -67,6 +67,6 @@ To tidy up your code, many languages support `Format Document` (<kbd>Alt+Shift+F
 If you want to apply this to only a subsection of the current document, select the desired region
 and pick `Format Selection` from the editor's context menu.
 
-## Prevent accidental close
+## Prevent Accidental Close
 
 To prevent accidental close of the editor using keyboard shortcuts like `CMD+W` or `CTRL+W`, you can set the `application.confirmExit` preference option to `always`.

--- a/src/docs/tips-and-tricks.md
+++ b/src/docs/tips-and-tricks.md
@@ -6,6 +6,7 @@
   * [Search in Workspace](#search-in-workspace)
   * [Symbols and References](#symbols-and-references)
   * [Format Document](#format-document)
+  * [Prevent accidental close](#prevent-accidental-close)
 
 ## Command Palette
 
@@ -65,3 +66,7 @@ you navigate between them in both directions:
 To tidy up your code, many languages support `Format Document` (<kbd>Alt+Shift+F</kbd>).
 If you want to apply this to only a subsection of the current document, select the desired region
 and pick `Format Selection` from the editor's context menu.
+
+## Prevent accidental close
+
+To prevent accidental close of the editor using keyboard shortcuts like `CMD+W` or `CTRL+W`, you can set the `application.confirmExit` preference option to `always`.


### PR DESCRIPTION
This will add a tip on how you can prevent accidental close of the editor, which happens frequently for users trying Gitpod.

See also https://github.com/gitpod-io/gitpod/issues/2648 and [relevant discussion](https://typefox.slack.com/archives/C01FESXGVTP/p1609841010019400) (internal).