### PR TITLE
docs: fix enumeration styles.

### DIFF
--- a/src/layouts/docs.tsx
+++ b/src/layouts/docs.tsx
@@ -72,6 +72,9 @@ const StyledDocsLayout = styled.div`
 
         ul, ol {
             margin: 2rem 0;
+        }
+
+        ul {
             list-style: inherit;
         }
 


### PR DESCRIPTION
Fixes enumeration styles on `/docs/`

![image](https://user-images.githubusercontent.com/46004116/104333618-45e04f80-5513-11eb-8804-f1c7ff56073a.png)
