### PR TITLE
[docs] Update example reposistories

### DIFF
--- a/src/docs/examples.md
+++ b/src/docs/examples.md
@@ -1,0 +1,19 @@
+# Example Projects
+
+Here are a few example projects that have already been configured for Gitpod.
+
+Take a look at their `.gitpod.yml` file and try them in Gitpod with a single click.
+
+| Language | Project | Try it |
+| --- | :--- | --- |
+| TypeScript | [Theia](https://github.com/eclipse-theia/theia), a cloud & desktop IDE framework implemented in TypeScript | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/eclipse-theia/theia) |
+| Go | [Prometheus](https://github.com/prometheus/prometheus), a monitoring system and time series database | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/prometheus/prometheus) |
+| Rust | [Nushell](https://github.com/nushell/nushell), a terminal emulator written in Rust | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nushell/nushell) |
+| Java | [Spring PetClinic](https://github.com/gitpod-io/spring-petclinic), a sample web application in Spring in Java | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/spring-petclinic) |
+| Python | [Todo List API in Python Flask](https://github.com/breatheco-de/python-flask-api-tutorial), an interactive tutorial about using Python Flask | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/breatheco-de/python-flask-api-tutorial) |
+| C# | [C# .NET Core template](https://github.com/gitpod-io/dotnetcore), a simple pipeline example for a .NET Core application | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/dotnetcore) |
+| Ruby | [Ruby on Rails template](https://github.com/gitpod-io/ruby-on-rails) with a PostgreSQL database | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/ruby-on-rails) |
+
+<br>
+
+You can find more example projects in the [Languages & Frameworks](/docs/languages-and-frameworks/) pages.

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -35,11 +35,9 @@ GitLab comes with a native Gitpod which is enabled by default for GitLab.com. To
 
 ## Example Project
 
-We've alrelay added Gitpod configuration for some example or existing projects.
+Many example projects already have a working Gitpod configuration. We've listed a few of them in [Example Projects](/docs/examples/) so that you can inspect their configurations and try them out in Gitpod.
 
-You can pick any of the example projects listed under [Languages & Frameworks](https://www.gitpod.io/docs/languages-and-frameworks/).
-
-For example, try opening [Vuepress](https://gitpod.io/#https://github.com/vuejs/vuepress) or a [Java with Spring Boot](https://gitpod.io/#https://github.com/gitpod-io/spring-petclinic) example.
+For instance, you could try opening [Vuepress](https://gitpod.io/#https://github.com/vuejs/vuepress) or a [Java with Spring Boot](https://gitpod.io/#https://github.com/gitpod-io/spring-petclinic) example.
 
 ## Gitpodified Open Source Projects {#gitpodified-open-source-project}
 

--- a/src/docs/languages/deno.md
+++ b/src/docs/languages/deno.md
@@ -44,10 +44,7 @@ Here is a useful extensions that you'll likely want to install in your Deno proj
 
 ### [Deno](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno)
 
-To add this extension to your repository, simply add these lines to your [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) configuration file:
+To add this extension to your repository, simply open Gitpod's Extensions panel (see left vertical menu in the IDE), then search for "Deno" and install it "for this project".
 
-```YAML
-vscode:
-  extensions:
-    - denoland.vscode-deno@2.3.1:EQc/TzIQd+H8BcYsPXTo/A==
-```
+Next, simply commit the [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) configuration file that was automatically created (or updated) by Gitpod.
+

--- a/src/docs/languages/dotnet.md
+++ b/src/docs/languages/dotnet.md
@@ -7,10 +7,9 @@
 
 | Repository | Description | Try it |
 |------|----------------|-----------|
-|[uno](https://github.com/unoplatform/uno)|Build Mobile, Desktop and WebAssembly apps with C# and XAML|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/unoplatform/uno)
-|[coolstore-microservices](https://github.com/vietnam-devs/coolstore-microservices)|A Kubernetes-based microservices application on service mesh written in C#|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/vietnam-devs/coolstore-microservices)|
+|[dotnetcore](https://github.com/gitpod-io/dotnetcore)|C# .NET Core template|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/dotnetcore)|
+|[uno](https://github.com/unoplatform/uno)|Build Mobile, Desktop and WebAssembly apps with C# and XAML|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/unoplatform/uno)|
 |[uno.quickstart](https://github.com/unoplatform/uno.quickstart)|An Uno "Hello world!" project using Windows UWP, iOS, Android and WebAssembly|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/unoplatform/uno.quickstart)|
-|[Fable](https://github.com/fable-compiler/Fable)|F# to JavaScript Compiler written in F#|[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/fable-compiler/Fable)|
 
 </div>
 
@@ -45,13 +44,9 @@ Alternatively, you can also run your application in so-called watch-mode. In suc
 
 ![C# Extension Demo](../images/CSharpDemo.png)
 
-This extension brings code completion, snippets, auto-formatting, peek definition, refactoring, and hover documentation for C#! To install this extension for your repository, add the following to your [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) file:
+This extension brings code completion, snippets, auto-formatting, peek definition, refactoring, and hover documentation for C#!
 
-```yaml
-vscode:
-  extensions:
-    - ms-vscode.csharp@1.21.12:kw8SkO8+aVTSFug281WfQQ==
-```
+To install this extension for your repository, open the **Extensions** panel in Gitpod (left vertical IDE menu), then search for "csharp" and install it "for this project". Next, commit the [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) file that was automatically created (or updated) by Gitpod.
 
 ### Ionide-fsharp
 

--- a/src/docs/languages/go.md
+++ b/src/docs/languages/go.md
@@ -10,10 +10,11 @@ Here are a few Go example projects that are already automated with Gitpod:
 
 | Repository                                                              |                                                                 Description                         |               Try It |
 | ----------------------------------------------------------------- | ------------------------------|-------------------------------------------------------------------------------------------------: |
-| [go-swagger/go-swagger](https://github.com/go-swagger/go-swagger) | A simple yet powerful representation of your RESTful API | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/go-swagger/go-swagger) |
-| [gitpod-io/go-gin-app](https://github.com/gitpod-io/go-gin-app)  | Gin example running in Gitpod |  [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/go-gin-app) |
-| [gosh-terminal/gosh](https://github.com/gosh-terminal/gosh)   | A terminal implemented in Go where you can do anything  |    [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gosh-terminal/gosh) |
-| [gitpod-io/self-hosted](https://github.com/gitpod-io/self-hosted) | Self-Host your Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/self-hosted) |
+| [prometheus](https://github.com/prometheus/prometheus) | The Prometheus monitoring system and time series database | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/prometheus/prometheus) |
+| [inlets](https://github.com/inlets/inlets) | Cloud Native Tunnel for APIs | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/inlets/inlets) |
+| [go-swagger](https://github.com/go-swagger/go-swagger) | A simple yet powerful representation of your RESTful API | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/go-swagger/go-swagger) |
+| [go-gin-app](https://github.com/gitpod-io/go-gin-app)  | Gin example running in Gitpod |  [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/go-gin-app) |
+| [gosh-terminal](https://github.com/gosh-terminal/gosh)   | A terminal implemented in Go where you can do anything  |    [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gosh-terminal/gosh) |
 
 </div>
 

--- a/src/docs/languages/javascript.md
+++ b/src/docs/languages/javascript.md
@@ -10,9 +10,9 @@ Here are a few JavaScript example projects that are automated with Gitpod:
 
 | Repository                                             | Description                                                                 | Try it                                                                                                                      |
 | ------------------------------------------------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| [MobX](https://github.com/mobxjs/mobx)                 | Simple, scalable state management.                                          | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mobxjs/mobx)         |
-| [Mozilla pdf.js](https://github.com/mozilla/pdf.js)    | PDF.js is a Portable Document Format (PDF) viewer that is built with HTML5. | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mozilla/pdf.js)      |
-| [Tesseract.js](https://github.com/naptha/tesseract.js) | Pure Javascript OCR for more than 100 Languages.                            | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/naptha/tesseract.js) |
+| [Tesseract.js](https://github.com/naptha/tesseract.js) | Pure JavaScript OCR for more than 100 Languages | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/naptha/tesseract.js) |
+| [freeCodeCamp](https://github.com/freeCodeCamp/freeCodeCamp) | [freeCodeCamp.org](https://www.freecodecamp.org/)'s open source codebase and curriculum | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/freeCodeCamp/freeCodeCamp) |
+| [Mozilla PDF.js](https://github.com/mozilla/pdf.js)    | PDF.js is a PDF viewer that is built with HTML5 | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mozilla/pdf.js) |
 
 </div>
 

--- a/src/docs/languages/kotlin.md
+++ b/src/docs/languages/kotlin.md
@@ -4,24 +4,40 @@ To work with Kotlin in Gitpod, you will need to properly configure your reposito
 
 ## Installing Kotlin
 
-To install Kotlin in Gitpod add the following to your [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/)
+To install Kotlin in Gitpod add the following to your [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/):
 
 ```Dockerfile
 RUN brew install kotlin
 ```
 
-A full example could look like
+A full example could look like this:
 
 ```Dockerfile
 FROM gitpod/workspace-full
 
 USER gitpod
-
 RUN brew install kotlin
 ```
 
+## VS Code Extensions
+
+### Kotlin Language
+
+This extension provides Kotlin language support for Gitpod and other IDEs, with:
+- Syntax highlighting
+- Code snippets
+- Region code folding
+
+To get it, open Gitpod's **Extensions** panel (left vertical menu), then search for "Kotlin" and install the extension by Mathias Fröhlich for your project. Next, commit the [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) file that was automatically created (or updated) by Gitpod.
+
+### Code Runner
+
+While this extension isn't Kotlin-specific, but allows to run code snippets in many different languages, including Kotlin.
+
+To get it, open Gitpod's Extensions panel, then search for "Code Runner" and install it for your project.
+
 ## Try it
 
-Please use the button below to see a basic repository with Kotlin support in Gitpod:
+Please use the button below to see a gitpodified [Kotlin example project](https://github.com/gitpod-io/Gitpod-Kotlin) in Gitpod:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Kotlin)

--- a/src/docs/languages/python.md
+++ b/src/docs/languages/python.md
@@ -10,10 +10,10 @@ Before we get started, here are some examples of already-[gitpodified](https://w
 
 | Repository                                                                                                |                                                                                                              Description |                                        Try it |
 -----------|-----------------------------------------------------------|----------------------------------------------------
-| [breatheco-de/python-flask-api-tutorial](https://github.com/breatheco-de/python-flask-api-tutorial) | A step by step Todo List API tutorial with Flask + Python | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/breatheco-de/python-flask-api-tutorial) |
-| [gitpod-io/django-locallibrary-tutorial](https://github.com/gitpod-io/django-locallibrary-tutorial) | An example website written in Django by MDN | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/django-locallibrary-tutorial) |
-| [gitpod-io/Gitpod-PyQt](https://github.com/gitpod-io/Gitpod-PyQt) | A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-PyQt) |
-| [gitpod-io/wxPython-example](https://github.com/gitpod-io/wxPython-example) | A wxPython example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/wxPython-example) |
+| [python-flask-api-tutorial](https://github.com/breatheco-de/python-flask-api-tutorial) | A step by step Todo List API tutorial with Flask + Python | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/breatheco-de/python-flask-api-tutorial) |
+| [django-locallibrary-tutorial](https://github.com/gitpod-io/django-locallibrary-tutorial) | An example website written in Django by MDN | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/django-locallibrary-tutorial) |
+| [Gitpod-PyQt](https://github.com/gitpod-io/Gitpod-PyQt) | A PyQt example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-PyQt) |
+| [wxPython-example](https://github.com/gitpod-io/wxPython-example) | A wxPython example for Gitpod | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/wxPython-example) |
 
 </div>
 

--- a/src/docs/languages/ruby.md
+++ b/src/docs/languages/ruby.md
@@ -15,10 +15,9 @@ Here are a few Ruby example projects that are already automated with Gitpod:
 
 Repository | Description | Try it
 ---------|----------|---------
-[rails_sample_app](https://github.com/gitpod-io/rails_sample_app) | Ruby on Rails tutorial sample application | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/rails_sample_app)
-[Gitpod-Ruby-On-Rails](https://github.com/gitpod-io/Gitpod-Ruby-On-Rails) | Minimal Ruby on Rails example | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/Gitpod-Ruby-On-Rails)
-[home-assistant.io](https://github.com/home-assistant/home-assistant.io) | Open source home automation | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/home-assistant/home-assistant.io)
-[dev.to](https://github.com/thepracticaldev/dev.to) | A platform where software developers write articles | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/thepracticaldev/dev.to)
+[Ruby on Rails template](https://github.com/gitpod-io/ruby-on-rails) | Ruby on Rails template with a PostgreSQL database | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-io/ruby-on-rails)
+[Forem](https://github.com/forem/forem) | The platform that powers [dev.to](https://dev.to) | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/forem/forem)
+[GitLab](https://gitlab.com/gitlab-org/gitlab) | The open source end-to-end software development platform | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://gitlab.com/gitlab-org/gitlab)
 
  </div>
 

--- a/src/docs/languages/ruby.md
+++ b/src/docs/languages/ruby.md
@@ -3,9 +3,22 @@
 It's relatively easy to set up your Ruby project in Gitpod.
 
 ## Ruby Versions
-Gitpod comes with Ruby 2.5 and 2.6 pre-installed (2.6 is the default).
+As of this writing, Gitpod comes with Ruby 2.6.6 pre-installed.
 
-To change the default Ruby version, you can simply run `rvm use 2.5 --default` in Gitpod's Terminal. You can also install other versions, e.g. by running `rvm install 2.7`.
+To use a different Ruby version (for example, 2.5.1) you can create a [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/) for your project, and then add something like the second paragraph to it:
+
+```Dockerfile
+FROM gitpod/workspace-full
+USER gitpod
+
+# Install Ruby version 2.5.1 and set it as default
+RUN echo "rvm_gems_path=/home/gitpod/.rvm" > ~/.rvmrc
+RUN bash -lc "rvm install ruby-2.5.1 && \
+              rvm use ruby-ruby-2.5.1 --default"
+RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+```
+
+> 💡 Explanation: Gitpod initially [sets up RVM](https://github.com/gitpod-io/workspace-images/blob/b4b8a2b796ce570efa3aef2fc9d12d5c9803d0d2/full/Dockerfile#L228-L243) in `/home/gitpod/.rvm`, but then later switches the RVM configuration directory to `/workspace/.rvm`, so that any user-made changes (like installing new gems) are persisted within a Gitpod workspace. However, during the Dockerfile build, the `/workspace` directory doesn't exist yet, so we temporarily reset RVM's configuration directory to `/home/gitpod/.rvm`.
 
 ## Example Repositories
 

--- a/src/docs/languages/rust.md
+++ b/src/docs/languages/rust.md
@@ -9,7 +9,7 @@ Rust is a first-class language in Gitpod, and we believe that Gitpod is a great 
 
 ## Rust Version
 
-Gitpod always comes with the latest available Rust toolchain pre-installed using [rustup](https://rustup.rs/). (As of 24 Nov 2020, the Rust version is `1.49.0`, and it's updated [semi-automatically](https://github.com/gitpod-io/workspace-images/pull/282/files) on every official Rust release.)
+Gitpod always comes with the latest available Rust toolchain pre-installed using [rustup](https://rustup.rs/). (As of this writing, the Rust version is `1.49.0` and it's updated [semi-automatically](https://github.com/gitpod-io/workspace-images/pull/282/files) on every official Rust release.)
 
 You can also use `rustup` yourself in Gitpod in order to switch to a different Rust version, or to install extra components. See the [the rustup book](https://rust-lang.github.io/rustup/index.html) to learn more about `rustup` itself.
 
@@ -39,8 +39,8 @@ Here are a few Rust example projects that are already automated with Gitpod:
 
 | Repository  | Description  | Try it    |
 |---------|------------|-----|
+|[Nushell](https://github.com/nushell/nushell/) | A next-gen shell for the GitHub era | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nushell/nushell) |
 |[MathLang](https://github.com/JesterOrNot/mathlang) | Basic maths language in Rust | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/JesterOrNot/MathLang) |
-|[NuShell](https://github.com/nushell/nushell/) | A next-gen shell for the GitHub era | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nushell/nushell) |
 |[Servo](https://github.com/servo/servo) | The Servo Browser Engine | [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/servo/servo) |
 
 </div>
@@ -76,7 +76,12 @@ Better TOML adds syntax highlighting to your `Cargo.toml`.
 
 ## Cross-compiling with MUSL
 
-TODO. See also [MUSL support for fully static binaries](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.html).
+To cross-compile with MUSL in Gitpod, you can:
+
+- Run `rustup target add x86_64-unknown-linux-musl`, for example in your [.gitpod.Dockerfile](https://www.gitpod.io/docs/config-docker/)
+- Then, build with `cargo build --target x86_64-unknown-linux-musl`
+
+To learn more, see [MUSL support for fully static binaries](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.html).
 
 ## Debugging
 

--- a/src/docs/languages/scala.md
+++ b/src/docs/languages/scala.md
@@ -122,36 +122,17 @@ image:
 
 ![Scala Syntax demo](../images/scala-syntax.png)
 
-Scala Syntax adds basic syntax highlighting for Scala and `sbt` files. To get it, add the following to your [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/) file:
+Scala Syntax adds basic syntax highlighting for Scala and `sbt` files.
 
-```YAML
-vscode:
-  extensions:
-    - scala-lang.scala@0.3.9:kklqw+c/dNRmtTU8B5repw==
-```
+To get it, open Gitpod's **Extensions** panel (left vertical menu in the IDE), then search for "Scala Syntax", and install it "for this project". Then, commit the automatic `.gitpod.yml` change that was made by Gitpod.
 
 ### Metals
 
 ![An example of the metals in Gitpod](../images/metals-demo.png)
 
-Metals adds helpful Scala features to Gitpod, for example, advanced autocompletion and debugging support just to name a few. Although to use it you must also use the previously mentioned Scala Syntax you should do the following
+Metals adds helpful Scala features to Gitpod, for example, advanced autocompletion and debugging support just to name a few. Although to use it you must also have the previously mentioned Scala Syntax.
 
-If you already added Scala Syntax put the following on the following line
-
-```YAML
-    - scalameta.metals@1.7.8:oixMSF1r3cXQPfOQ34+sTA==
-```
-
-Otherwise, add the following to your [.gitpod.yml](https://www.gitpod.io/docs/config-gitpod-file/)
-
-```YAML
-vscode:
-  extensions:
-    - scala-lang.scala@0.3.9:kklqw+c/dNRmtTU8B5repw==
-    - scalameta.metals@1.7.8:oixMSF1r3cXQPfOQ34+sTA==
-```
-
-Either way, the end result should look like the snippet above.
+To get it, open Gitpod's **Extensions** panel (left vertical menu in the IDE), then search for "Scala Metals", and install it "for this project". Then, commit the automatic `.gitpod.yml` change that was made by Gitpod.
 
 Boom! You're done! (Just a reminder, don't forget to push the changes.)
 

--- a/src/docs/menu.ts
+++ b/src/docs/menu.ts
@@ -19,7 +19,13 @@ export const MENU: MenuEntry[] = [
     ),
     M(
         "Getting Started",
-        "getting-started"
+        "getting-started",
+        [
+            M(
+                "Example Projects",
+                "examples"
+            ),
+        ],
     ),
     M(
         "Workspaces",


### PR DESCRIPTION
TODO:
- [x] Update example repositories in [Languages & Frameworks](https://www.gitpod.io/docs/languages-and-frameworks/) according to what's now [on the website](https://www.gitpod.io/#get-started)
- [x] Maybe add a new page under [Getting Started](https://www.gitpod.io/docs/getting-started/) with just a few example repos we recommend?
- [x] Fix https://github.com/gitpod-io/gitpod/issues/3030