### PR TITLE
[docs] Embed new screencasts into relevant docs sections

### DIFF
--- a/src/docs/configuration.md
+++ b/src/docs/configuration.md
@@ -2,6 +2,8 @@
 
 Gitpod dev environments are started with a single click. In order to make sure they come fully initialized and with the tools you need, you should provide a configuration file.
 
+`youtube: ZgY6a78mAnQ`
+
 ## Setup Assistant
 
 The setup assistant can help you get started with this. Once you open a project without a `.gitpod.yml` you should see a notification in the bottom right that lets you start the assistant.

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -11,6 +11,8 @@ You can start using Gitpod with one or more of the following ways:
 - Enable [GitLab Integration](#gitlab-integration)
 - Quick start using an [Example Project](#example-project) or [OSS Project](#gitpodified-open-source-project)
 
+`youtube: ZZ0_TQ6UApY`
+
 ## Prefixed URL
 
 You can quickly open a new workspace for your project using a context URL like repository, branch, pull request, issue, or file. Just prefix the URL in the address bar of your browser with `gitpod.io/#`.

--- a/src/docs/prebuilds.md
+++ b/src/docs/prebuilds.md
@@ -4,6 +4,8 @@ Whenever your code changes (e.g. when new commits are pushed to your repository)
 
 Then, when you do create a new workspace on a branch, or Pull/Merge Request, for which a prebuild exists, this workspace will load much faster, because all dependencies will have been already downloaded ahead of time, and your code will be already compiled.
 
+`youtube: KR8ESjGYsXI`
+
 ## Enable Prebuilt Workspaces
 
 ### On GitHub

--- a/src/docs/sharing-and-collaboration.md
+++ b/src/docs/sharing-and-collaboration.md
@@ -5,6 +5,8 @@ There are two different ways to share your workspaces:
  - [Sharing Running Workspaces](#sharing-running-workspaces)
  - [Sharing Snapshots](#sharing-snapshots)
 
+`youtube: 9RftoWFzJ2s`
+
 ## Sharing Running Workspaces
 
 Sharing running workspaces makes it possible to quickly look at a workspace together with a (remote) colleague.


### PR DESCRIPTION
This idea just hit me – why not embed the new screencasts into the relevant docs sections, in order to give a quick overview of what the docs page is about.

I'm not married to the idea, but thought it could be helpful. Any feedback (for or against this) is very welcome.

Relevant URLs:
- Screencast 1 → https://deploy-preview-978--gitpod-website.netlify.app/docs/getting-started/
- Screencast 2 → (I didn't find a relevant page for "how to configure your color theme, editor, and extensions" 😬)
- Screencast 3 → https://deploy-preview-978--gitpod-website.netlify.app/docs/configuration/
- Screencast 4 → https://deploy-preview-978--gitpod-website.netlify.app/docs/prebuilds/
- Screencast 5 → ("ideal workflow" / "ephemeral workspaces"?)
- Screencast 6 → https://deploy-preview-978--gitpod-website.netlify.app/docs/sharing-and-collaboration/