### PR TITLE
[docs] fix: grammatical error

### DIFF
--- a/src/docs/config-start-tasks.md
+++ b/src/docs/config-start-tasks.md
@@ -20,7 +20,7 @@ tasks:
 - command: echo Terminal1
 - command: echo Terminal2
 ```
-They are started in parallel. See [belows options](#openin) on configuring where and how the terminals are placed in the workbench.
+They are started in parallel. See [below options](#openin) on configuring where and how the terminals are placed in the workbench.
 
 ## Defining Commands
 


### PR DESCRIPTION
### Proposed Changes

There was a grammatical error [here in the gitpod docs](https://www.gitpod.io/docs/config-start-tasks/#start-tasks) .

![image](https://user-images.githubusercontent.com/55396651/107851513-94457e80-6e30-11eb-9771-b6dde25cf62c.png)


I have correct the above by **changing *belows options* to *below options***