### PR TITLE
Redirect /changelog to /docs/changelog.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -411,3 +411,8 @@
   from = "/gitpod-vs-codespaces"
   to = "/gitpod-vs-github-codespaces/"
   status = 301
+
+[[redirects]]
+  from = "/changelog"
+  to = "/docs/changelog/"
+  status = 301


### PR DESCRIPTION
Relates to #999.

This PR introduces a new `/changelog` URL. At this time, `/changelog` redirects to the existing `/docs/changelog`, but provides a standardized URL format of www.gitpod.io/changelog which can be shared on social media, blog posts, etc.

A follow-up PR will address the remaining work outlined in #999.