### PR TITLE
security: move security.txt to website from gitpod-io/gitpod

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Community
+    url: https://community.gitpod.io
+    about: Please ask and answer usage questions here.
+  - name: Security
+    url: https://www.gitpod.io/security
+    about: Please report security vulnerabilities here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue please visit https://gitpod.io/security

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,11 @@
   functions = "lambda"
 
 [[redirects]]
+  from = "/security"
+  to = "/.well-known/security.txt"
+  status = 302
+
+[[redirects]]
   from = "/gitpod-business.html"
   to = "/pricing/#enterprise"
   status = 301

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: security@gitpod.io
+Preferred-Languages: en, de
+Canonical: https://www.gitpod.io/.well-known/security.txt
+Hiring: https://gitpod.io/careers


### PR DESCRIPTION
**currently**

1. Accessing `https://www.gitpod.io/security` or `https://www.gitpod.io/.well-known/security.txt` is 404
1. Accessing `https://gitpod.io/security.txt` functions but the hiring link in https://github.com/gitpod-io/gitpod/blob/c8526aeff02a354c1b0a5845bde07b36fa455ae6/components/dashboard/public/.well-known/security.txt is out of date.

**changes**

- Move `security.txt` into the website, resolve hiring link, add a handy redirect and resolve 404.
- https://github.com/gitpod-io/gitpod/pull/3459 implements the redirect from `https://gitpod.io/security.txt` to `https://www.gitpod.io/.well-known/security.txt`
- Wires up https://docs.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository (`SECURITY.md`)
- Creates GitHub issue template redirect to `https://www.gitpod.io/security`