### PR TITLE
Document .editorconfig as alternative to settings.json

### DIFF
--- a/src/docs/config-editor.md
+++ b/src/docs/config-editor.md
@@ -4,11 +4,14 @@ Gitpod uses [Theia](https://github.com/eclipse-theia/theia) as its IDE which can
 
 Workspace settings are stored in a file within your project. They can reside either in:
  - `$GITPOD_REPO_ROOT/.theia/settings.json` or
- - `$GITPOD_REPO_ROOT/.vscode/settings.json`
+ - `$GITPOD_REPO_ROOT/.vscode/settings.json` or
+ - `$GITPOD_REPO_ROOT/.editorconfig`
 
 User settings override workspace settings and can be configured through the preferences editor, which you can open through the menu (`File -> Preferences`).
 
 The available properties and their possible values are proposed in the editor and are the same as in VS Code.
+
+Additionally you can keep settings in [`editorconfig` format](https://editorconfig.org) that takes precedence over other settings.
 
 <h2 class="h3">Example Configuration</h2>
 


### PR DESCRIPTION
See gitpod-io/gitpod#896 for context