### PR TITLE
Title changes based on documentation page

### DIFF
--- a/src/components/docs/docs-content-layout.svelte
+++ b/src/components/docs/docs-content-layout.svelte
@@ -1,7 +1,9 @@
 <script>
+  import OpenGraph from "../open-graph.svelte";
   import docsCurrentSectionStore from "../../stores/docs-current-section";
 
   export let section;
+  export let title;
 
   $: $docsCurrentSectionStore = section;
 </script>
@@ -10,6 +12,14 @@
   @import "../../assets/docs";
 </style> -->
 
+<OpenGraph
+  data={{
+    description:
+      "Explore the documentation to learn more about Gitpod.io and Gitpod Self-Hosted.",
+    title: title ? title : "Gitpod Documentation",
+    type: "website",
+  }}
+/>
 <div class="content-docs">
   <slot />
 </div>

--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Menu from "../../components/docs/menu.svelte";
   import MobileMenu from "../../components/docs/mobile-menu/index.svelte";
-  import OpenGraph from "../../components/open-graph.svelte";
   import Search from "../../components/docs/search.svelte";
   import "../../assets/docs.scss";
 
@@ -129,14 +128,6 @@
   }
 </style>
 
-<OpenGraph
-  data={{
-    description:
-      "Explore the documentation to learn more about Gitpod.io and Gitpod Self-Hosted.",
-    title: "Gitpod Documentation",
-    type: "website",
-  }}
-/>
 <div class="docs-layout row">
   <div class="menu">
     <Menu {MENU} />

--- a/src/routes/docs/bitbucket-integration.md
+++ b/src/routes/docs/bitbucket-integration.md
@@ -1,5 +1,6 @@
 ---
 section: integrations
+title: Bitbucket Integration
 ---
 
 # Bitbucket Integration

--- a/src/routes/docs/browser-extension.md
+++ b/src/routes/docs/browser-extension.md
@@ -1,5 +1,6 @@
 ---
 section: integrations
+title: Browser Extension
 ---
 
 # Browser Extension

--- a/src/routes/docs/changelog.md
+++ b/src/routes/docs/changelog.md
@@ -1,5 +1,6 @@
 ---
 section: changelog
+title: Changelog
 ---
 
 # Changelog

--- a/src/routes/docs/checkout-location.md
+++ b/src/routes/docs/checkout-location.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Checkout and Workspace Location
 ---
 
 # Checkout and Workspace Location

--- a/src/routes/docs/command-line-interface.md
+++ b/src/routes/docs/command-line-interface.md
@@ -1,5 +1,6 @@
 ---
 section: workspaces
+title: Command Line Interface
 ---
 
 # Command Line Interface

--- a/src/routes/docs/config-docker.md
+++ b/src/routes/docs/config-docker.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Docker Configuration
 ---
 
 # Docker Configuration

--- a/src/routes/docs/config-editor.md
+++ b/src/routes/docs/config-editor.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Editor Configuration
 ---
 
 # Editor Configuration

--- a/src/routes/docs/config-gitpod-file.md
+++ b/src/routes/docs/config-gitpod-file.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: .gitpod.yml
 ---
 
 # .gitpod.yml

--- a/src/routes/docs/config-ports.md
+++ b/src/routes/docs/config-ports.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Exposing Ports
 ---
 
 # Exposing Ports

--- a/src/routes/docs/config-start-tasks.md
+++ b/src/routes/docs/config-start-tasks.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Start Tasks
 ---
 
 # Start Tasks

--- a/src/routes/docs/configuration.md
+++ b/src/routes/docs/configuration.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Configure Your Project
 ---
 
 # Configure Your Project

--- a/src/routes/docs/context-urls.md
+++ b/src/routes/docs/context-urls.md
@@ -1,5 +1,6 @@
 ---
 section: workspaces
+title: Context URLs
 ---
 
 # Context URLs

--- a/src/routes/docs/environment-variables.md
+++ b/src/routes/docs/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Environment Variables
 ---
 
 # Environment Variables

--- a/src/routes/docs/examples.md
+++ b/src/routes/docs/examples.md
@@ -1,5 +1,6 @@
 ---
 section: getting-started
+title: Example Projects
 ---
 
 # Example Projects

--- a/src/routes/docs/feature-preview.md
+++ b/src/routes/docs/feature-preview.md
@@ -1,5 +1,6 @@
 ---
 section: feature-preview
+title: Feature Preview
 ---
 
 # Feature Preview

--- a/src/routes/docs/getting-started.md
+++ b/src/routes/docs/getting-started.md
@@ -1,5 +1,6 @@
 ---
 section: getting-started
+title: Getting Started
 ---
 
 # Getting Started

--- a/src/routes/docs/github-integration.md
+++ b/src/routes/docs/github-integration.md
@@ -1,5 +1,6 @@
 ---
 section: integrations
+title: GitHub Integration
 ---
 
 # GitHub Integration

--- a/src/routes/docs/gitlab-integration.md
+++ b/src/routes/docs/gitlab-integration.md
@@ -1,5 +1,6 @@
 ---
 section: integrations
+title: GitLab Integration
 ---
 
 # GitLab Integration

--- a/src/routes/docs/integrations.md
+++ b/src/routes/docs/integrations.md
@@ -1,5 +1,6 @@
 ---
 section: integrations
+title: Integrations
 ---
 
 # Integrations

--- a/src/routes/docs/languages-and-frameworks.md
+++ b/src/routes/docs/languages-and-frameworks.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Languages & Frameworks
 ---
 
 # Languages & Frameworks

--- a/src/routes/docs/languages/bash.md
+++ b/src/routes/docs/languages/bash.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Bash in Gitpod
 ---
 
 # Bash in Gitpod

--- a/src/routes/docs/languages/cpp.md
+++ b/src/routes/docs/languages/cpp.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: C++ in Gitpod
 ---
 
 # C++ in Gitpod

--- a/src/routes/docs/languages/dart.md
+++ b/src/routes/docs/languages/dart.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Dart in Gitpod
 ---
 
 # Dart in Gitpod

--- a/src/routes/docs/languages/deno.md
+++ b/src/routes/docs/languages/deno.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Deno in Gitpod
 ---
 
 # Deno in Gitpod

--- a/src/routes/docs/languages/dotnet.md
+++ b/src/routes/docs/languages/dotnet.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: .NET in Gitpod
 ---
 
 # .NET in Gitpod

--- a/src/routes/docs/languages/go.md
+++ b/src/routes/docs/languages/go.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Go in Gitpod
 ---
 
 # Go in Gitpod

--- a/src/routes/docs/languages/html.md
+++ b/src/routes/docs/languages/html.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: HTML & CSS in Gitpod
 ---
 
 # HTML & CSS in Gitpod

--- a/src/routes/docs/languages/java.md
+++ b/src/routes/docs/languages/java.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Java in Gitpod
 ---
 
 # Java in Gitpod

--- a/src/routes/docs/languages/javascript.md
+++ b/src/routes/docs/languages/javascript.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: JavaScript in Gitpod
 ---
 
 # JavaScript in Gitpod

--- a/src/routes/docs/languages/julia.md
+++ b/src/routes/docs/languages/julia.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Julia in Gitpod
 ---
 
 # Julia in Gitpod

--- a/src/routes/docs/languages/kotlin.md
+++ b/src/routes/docs/languages/kotlin.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Kotlin in Gitpod
 ---
 
 # Kotlin in Gitpod

--- a/src/routes/docs/languages/latex.md
+++ b/src/routes/docs/languages/latex.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: LaTeX in Gitpod
 ---
 
 # LaTeX in Gitpod

--- a/src/routes/docs/languages/php.md
+++ b/src/routes/docs/languages/php.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: PHP in Gitpod
 ---
 
 # PHP in Gitpod

--- a/src/routes/docs/languages/python.md
+++ b/src/routes/docs/languages/python.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Python in Gitpod
 ---
 
 # Python in Gitpod

--- a/src/routes/docs/languages/r.md
+++ b/src/routes/docs/languages/r.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: R in Gitpod
 ---
 
 # R in Gitpod

--- a/src/routes/docs/languages/ruby.md
+++ b/src/routes/docs/languages/ruby.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Ruby in Gitpod
 ---
 
 # Ruby in Gitpod

--- a/src/routes/docs/languages/rust.md
+++ b/src/routes/docs/languages/rust.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Rust in Gitpod
 ---
 
 # Rust in Gitpod

--- a/src/routes/docs/languages/scala.md
+++ b/src/routes/docs/languages/scala.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Scala in Gitpod
 ---
 
 # Scala in Gitpod

--- a/src/routes/docs/languages/svelte.md
+++ b/src/routes/docs/languages/svelte.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Svelte in Gitpod
 ---
 
 # Svelte in Gitpod

--- a/src/routes/docs/languages/vue.md
+++ b/src/routes/docs/languages/vue.md
@@ -1,5 +1,6 @@
 ---
 section: languages-and-frameworks
+title: Vue.js in Gitpod
 ---
 
 # Vue.js in Gitpod

--- a/src/routes/docs/life-of-workspace.md
+++ b/src/routes/docs/life-of-workspace.md
@@ -1,5 +1,6 @@
 ---
 section: workspaces
+title: Life of a Workspace
 ---
 
 # Life of a Workspace

--- a/src/routes/docs/prebuilds.md
+++ b/src/routes/docs/prebuilds.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: Prebuilds
 ---
 
 # Prebuilds

--- a/src/routes/docs/professional-open-source.md
+++ b/src/routes/docs/professional-open-source.md
@@ -1,5 +1,6 @@
 ---
 section: subscriptions
+title: Professional Open Source
 ---
 
 # Professional Open Source

--- a/src/routes/docs/self-hosted/0.3.0/admin/admin.md
+++ b/src/routes/docs/self-hosted/0.3.0/admin/admin.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Administrate Gitpod Self-Hosted
 ---
 
 # Administrate Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/0.3.0/install/database.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/database.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Database
 ---
 
 # Database

--- a/src/routes/docs/self-hosted/0.3.0/install/docker-registry.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/docker-registry.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Docker Registry
 ---
 
 # Docker Registry

--- a/src/routes/docs/self-hosted/0.3.0/install/helm-2x.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/helm-2x.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Helm
 ---
 
 # Helm

--- a/src/routes/docs/self-hosted/0.3.0/install/https-certs.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/https-certs.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: HTTPS certificates
 ---
 
 # HTTPS certificates

--- a/src/routes/docs/self-hosted/0.3.0/install/install-on-gcp-manual.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/install-on-gcp-manual.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Manually Install Gitpod on Google Cloud Platform
 ---
 
 # Manually Install Gitpod on Google Cloud Platform

--- a/src/routes/docs/self-hosted/0.3.0/install/install-on-gcp-script.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/install-on-gcp-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Install Gitpod on Google Cloud Platform
 ---
 
 # Install Gitpod on Google Cloud Platform

--- a/src/routes/docs/self-hosted/0.3.0/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/install-on-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Install Gitpod Self-Hosted on Kubernetes
 ---
 
 # Install Gitpod Self-Hosted on Kubernetes

--- a/src/routes/docs/self-hosted/0.3.0/install/nodes.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/nodes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Kubernetes Nodes
 ---
 
 # Kubernetes Nodes

--- a/src/routes/docs/self-hosted/0.3.0/install/oauth.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/oauth.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: How To integrate Gitpod with OAuth providers
 ---
 
 # How To integrate Gitpod with OAuth providers
@@ -13,8 +14,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/github/callback
+  https://<your-domain.com>/auth/github/callback
 
 - copy the following values and configure them in `values.yaml`:
   - `clientId`
@@ -27,8 +27,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
+  https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
 
 - set "Scopes" to `api`, `read_user` and `read_repository`.
 - copy the following values and configure them in `values.yaml`:

--- a/src/routes/docs/self-hosted/0.3.0/install/prepare-installation.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/prepare-installation.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Prerequisites
 ---
 
 # Prerequisites

--- a/src/routes/docs/self-hosted/0.3.0/install/storage.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/storage.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Workspace Storage
 ---
 
 # Workspace Storage

--- a/src/routes/docs/self-hosted/0.3.0/install/workspaces.md
+++ b/src/routes/docs/self-hosted/0.3.0/install/workspaces.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Workspaces
 ---
 
 # Workspaces

--- a/src/routes/docs/self-hosted/0.3.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.3.0/self-hosted.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.3.0/self-hosted
+title: Gitpod Self-Hosted
 ---
 
 # Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/0.4.0/admin/admin.md
+++ b/src/routes/docs/self-hosted/0.4.0/admin/admin.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Administrate Gitpod Self-Hosted
 ---
 
 # Administrate Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/0.4.0/install/database.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/database.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Database
 ---
 
 # Database

--- a/src/routes/docs/self-hosted/0.4.0/install/docker-registry.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/docker-registry.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Docker Registry
 ---
 
 # Docker Registry

--- a/src/routes/docs/self-hosted/0.4.0/install/domain.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/domain.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Domain
 ---
 
 # Domain

--- a/src/routes/docs/self-hosted/0.4.0/install/helm-2x.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/helm-2x.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Helm
 ---
 
 # Helm

--- a/src/routes/docs/self-hosted/0.4.0/install/https-certs.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/https-certs.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: HTTPS certificates
 ---
 
 # HTTPS certificates

--- a/src/routes/docs/self-hosted/0.4.0/install/install-on-gcp-manual.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/install-on-gcp-manual.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Manually Install Gitpod on Google Cloud Platform
 ---
 
 # Manually Install Gitpod on Google Cloud Platform

--- a/src/routes/docs/self-hosted/0.4.0/install/install-on-gcp-script.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/install-on-gcp-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Install Gitpod on Google Cloud Platform
 ---
 
 # Install Gitpod on Google Cloud Platform

--- a/src/routes/docs/self-hosted/0.4.0/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/install-on-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Install Gitpod Self-Hosted on Kubernetes
 ---
 
 # Install Gitpod Self-Hosted on Kubernetes

--- a/src/routes/docs/self-hosted/0.4.0/install/nodes.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/nodes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Kubernetes Nodes
 ---
 
 # Kubernetes Nodes

--- a/src/routes/docs/self-hosted/0.4.0/install/oauth.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/oauth.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: How To integrate Gitpod with OAuth providers
 ---
 
 # How To integrate Gitpod with OAuth providers
@@ -25,8 +26,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/github/callback
+  https://<your-domain.com>/auth/github/callback
 
 - copy the following values and configure them in `values.yaml`:
   - `clientId`
@@ -39,8 +39,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
+  https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
 
 - set "Scopes" to `api`, `read_user` and `read_repository`.
 - copy the following values and configure them in `values.yaml`:

--- a/src/routes/docs/self-hosted/0.4.0/install/storage.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/storage.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Workspace Storage
 ---
 
 # Workspace Storage

--- a/src/routes/docs/self-hosted/0.4.0/install/workspaces.md
+++ b/src/routes/docs/self-hosted/0.4.0/install/workspaces.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Workspaces
 ---
 
 # Workspaces

--- a/src/routes/docs/self-hosted/0.4.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.4.0/self-hosted.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.4.0/self-hosted
+title: Gitpod Self-Hosted
 ---
 
 # Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/0.5.0/admin/admin.md
+++ b/src/routes/docs/self-hosted/0.5.0/admin/admin.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Administrate Gitpod Self-Hosted
 ---
 
 # Administrate Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/0.5.0/install/database.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/database.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Database
 ---
 
 # Database

--- a/src/routes/docs/self-hosted/0.5.0/install/docker-registry.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/docker-registry.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Docker Registry
 ---
 
 # Docker Registry

--- a/src/routes/docs/self-hosted/0.5.0/install/domain.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/domain.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Domain
 ---
 
 # Domain

--- a/src/routes/docs/self-hosted/0.5.0/install/helm-2x.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/helm-2x.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Helm
 ---
 
 # Helm

--- a/src/routes/docs/self-hosted/0.5.0/install/https-certs.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/https-certs.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: HTTPS certificates
 ---
 
 # HTTPS certificates

--- a/src/routes/docs/self-hosted/0.5.0/install/install-on-aws-script.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/install-on-aws-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Getting started with Gitpod on AWS
 ---
 
 # Getting started with Gitpod on AWS

--- a/src/routes/docs/self-hosted/0.5.0/install/install-on-gcp-manual.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/install-on-gcp-manual.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Manually Install Gitpod on Google Cloud Platform
 ---
 
 # Manually Install Gitpod on Google Cloud Platform

--- a/src/routes/docs/self-hosted/0.5.0/install/install-on-gcp-script.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/install-on-gcp-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Getting started with Gitpod on GCP
 ---
 
 # Getting started with Gitpod on GCP

--- a/src/routes/docs/self-hosted/0.5.0/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/install-on-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Install Gitpod Self-Hosted on Kubernetes
 ---
 
 # Install Gitpod Self-Hosted on Kubernetes

--- a/src/routes/docs/self-hosted/0.5.0/install/nodes.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/nodes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Kubernetes Nodes
 ---
 
 # Kubernetes Nodes

--- a/src/routes/docs/self-hosted/0.5.0/install/oauth.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/oauth.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: How To integrate Gitpod with OAuth providers
 ---
 
 # How To integrate Gitpod with OAuth providers
@@ -25,8 +26,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/github/callback
+  https://<your-domain.com>/auth/github/callback
 
 - copy the following values and configure them in `values.yaml`:
   - `clientId`
@@ -39,8 +39,7 @@ Follow the guide linked above and:
 
 - set "Authentication callback URL" to:
 
-
-    https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
+  https://<your-domain.com>/auth/<gitlab.com-OR-your-gitlab.com>/callback
 
 - set "Scopes" to `api`, `read_user` and `read_repository`.
 - copy the following values and configure them in `values.yaml`:

--- a/src/routes/docs/self-hosted/0.5.0/install/storage.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/storage.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Workspace Storage
 ---
 
 # Workspace Storage

--- a/src/routes/docs/self-hosted/0.5.0/install/workspaces.md
+++ b/src/routes/docs/self-hosted/0.5.0/install/workspaces.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Workspaces
 ---
 
 # Workspaces

--- a/src/routes/docs/self-hosted/0.5.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.5.0/self-hosted.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/0.5.0/self-hosted
+title: Gitpod Self-Hosted
 ---
 
 # Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/latest/admin/admin.md
+++ b/src/routes/docs/self-hosted/latest/admin/admin.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Administrate Gitpod Self-Hosted
 ---
 
 # Administrate Gitpod Self-Hosted

--- a/src/routes/docs/self-hosted/latest/install/configure-ingress.md
+++ b/src/routes/docs/self-hosted/latest/install/configure-ingress.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Configure Ingress to your Gitpod installation
 ---
 
 # Configure Ingress to your Gitpod installation

--- a/src/routes/docs/self-hosted/latest/install/database.md
+++ b/src/routes/docs/self-hosted/latest/install/database.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Database
 ---
 
 # Database

--- a/src/routes/docs/self-hosted/latest/install/docker-registry.md
+++ b/src/routes/docs/self-hosted/latest/install/docker-registry.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Docker Registry
 ---
 
 # Docker Registry

--- a/src/routes/docs/self-hosted/latest/install/install-on-aws-script.md
+++ b/src/routes/docs/self-hosted/latest/install/install-on-aws-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Getting started with Gitpod on AWS
 ---
 
 > Since the `0.6.0` release (December 2019) the installers are broken. We're working on bringing those back with one of the next releases.

--- a/src/routes/docs/self-hosted/latest/install/install-on-gcp-script.md
+++ b/src/routes/docs/self-hosted/latest/install/install-on-gcp-script.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Getting started with Gitpod on GCP
 ---
 
 > Since the `0.6.0` release (December 2019) the installers are broken. We're working on bringing those back with one of the next releases.

--- a/src/routes/docs/self-hosted/latest/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/latest/install/install-on-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Install Gitpod Self-Hosted on Kubernetes
 ---
 
 # Install Gitpod Self-Hosted on Kubernetes

--- a/src/routes/docs/self-hosted/latest/install/nodes.md
+++ b/src/routes/docs/self-hosted/latest/install/nodes.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Kubernetes Nodes
 ---
 
 # Kubernetes Nodes

--- a/src/routes/docs/self-hosted/latest/install/oauth.md
+++ b/src/routes/docs/self-hosted/latest/install/oauth.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: How To integrate Gitpod with OAuth providers
 ---
 
 # How To integrate Gitpod with OAuth providers

--- a/src/routes/docs/self-hosted/latest/install/storage.md
+++ b/src/routes/docs/self-hosted/latest/install/storage.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Workspace Storage
 ---
 
 # Workspace Storage

--- a/src/routes/docs/self-hosted/latest/install/troubleshooting.md
+++ b/src/routes/docs/self-hosted/latest/install/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Troubleshooting
 ---
 
 # Troubleshooting

--- a/src/routes/docs/self-hosted/latest/install/upgrade.md
+++ b/src/routes/docs/self-hosted/latest/install/upgrade.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Gitpod Self-Hosted Upgrade Notes
 ---
 
 # Gitpod Self-Hosted Upgrade Notes

--- a/src/routes/docs/self-hosted/latest/install/workspaces.md
+++ b/src/routes/docs/self-hosted/latest/install/workspaces.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Workspaces
 ---
 
 # Workspaces

--- a/src/routes/docs/self-hosted/latest/self-hosted.md
+++ b/src/routes/docs/self-hosted/latest/self-hosted.md
@@ -1,5 +1,6 @@
 ---
 section: self-hosted/latest/self-hosted
+title: Gitpod Self-Hosted
 ---
 
 # Gitpod Self-Hosted

--- a/src/routes/docs/sharing-and-collaboration.md
+++ b/src/routes/docs/sharing-and-collaboration.md
@@ -1,5 +1,6 @@
 ---
 section: workspaces
+title: Collaboration & Sharing of Workspaces
 ---
 
 # Collaboration & Sharing of Workspaces

--- a/src/routes/docs/subscriptions.md
+++ b/src/routes/docs/subscriptions.md
@@ -1,5 +1,6 @@
 ---
 section: subscriptions
+title: Subscriptions
 ---
 
 # Subscriptions

--- a/src/routes/docs/teams.md
+++ b/src/routes/docs/teams.md
@@ -1,5 +1,6 @@
 ---
 section: subscriptions
+title: Create a Team
 ---
 
 # Create a Team

--- a/src/routes/docs/vscode-extensions.md
+++ b/src/routes/docs/vscode-extensions.md
@@ -1,5 +1,6 @@
 ---
 section: configuration
+title: VS Code Extensions
 ---
 
 # VS Code Extensions

--- a/src/routes/docs/workspaces.md
+++ b/src/routes/docs/workspaces.md
@@ -1,5 +1,6 @@
 ---
 section: workspaces
+title: Workspaces
 ---
 
 # Workspaces


### PR DESCRIPTION
Let me just preface by saying Svelte makes my head spin. 

Objective: 
Have the document title change based on the documentation title.

Possible solution: 
Add a `title` property to each `.md` file and import it inside `docs-content-layout`, and pass that as a prop to <OpenGraph />. I didn't go with this because it meant I would have to update each `.md` file to include the property `title`. Maybe there's a better way...

Solution:
Have an `onMount` that grabs the `innerText` of the first `h1`, which is present on every `.md` file, and pass that as a prop to the `<OpenGraph />` component. 

Blockers: This implementation isn't done yet. Between renders, it's possible to see the fallback text flash for a second before the correct title appears. I'm unfamiliar with Svelte, so therefore I'm requesting a little bit of help. 
@jankeromnes  @gtsiolis 