### PR TITLE
Website prop now optional and defaults to "website"

### DIFF
--- a/src/components/docs/docs-content-layout.svelte
+++ b/src/components/docs/docs-content-layout.svelte
@@ -17,7 +17,6 @@
     description:
       "Explore the documentation to learn more about Gitpod.io and Gitpod Self-Hosted.",
     title: title ? title : "Gitpod Documentation",
-    type: "website",
   }}
 />
 <div class="content-docs">

--- a/src/components/open-graph.svelte
+++ b/src/components/open-graph.svelte
@@ -8,7 +8,7 @@
     description,
     image = "images/media-image.jpg",
     title,
-    type,
+    type = "website",
     imageTwitter = "images/media-image-twitter.jpg",
   } = data || {};
 

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -71,7 +71,6 @@
   data={{
     description: "On a mission to make developers' lives easier!",
     title: "About Gitpod",
-    type: "website",
   }}
 />
 <header class="tight">

--- a/src/routes/blog/index.svelte
+++ b/src/routes/blog/index.svelte
@@ -36,7 +36,6 @@
       description:
         "Visit the Gitpod blog to learn about releases, tutorials, news and more.",
       title: "Blog",
-      type: "website",
     }}
   />
   <section>

--- a/src/routes/careers.svelte
+++ b/src/routes/careers.svelte
@@ -54,7 +54,6 @@
   data={{
     description: "Come join our fast-growing, venture-backed team.",
     title: "Careers at Gitpod",
-    type: "website",
   }}
 />
 <header class="tight">

--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -128,7 +128,6 @@
   data={{
     description: "Reach out if you have any questions regarding Gitpod.",
     title: "Contact us",
-    type: "website",
   }}
 />
 <header class="tight">

--- a/src/routes/education.svelte
+++ b/src/routes/education.svelte
@@ -128,7 +128,6 @@
     description:
       "Gitpod simplifies the onboarding process, makes coding accessible from anywhere, and provides a productive learning environment.",
     title: "Education",
-    type: "website",
   }}
 />
 <header>

--- a/src/routes/features.svelte
+++ b/src/routes/features.svelte
@@ -105,7 +105,6 @@
     description:
       "Learn about Gitpod's collaboration tools, workspace snapshots, supported programming languages, and much more.",
     title: "Features",
-    type: "website",
   }}
 />
 

--- a/src/routes/gitpod-vs-github-codespaces.svelte
+++ b/src/routes/gitpod-vs-github-codespaces.svelte
@@ -130,7 +130,6 @@
     description:
       "Gitpod is the faster, more powerful, open-source platform that integrates with your individual stack.",
     title: "Gitpod vs GitHub Codespaces",
-    type: "website",
   }}
 />
 <header>

--- a/src/routes/imprint.svelte
+++ b/src/routes/imprint.svelte
@@ -10,7 +10,6 @@
   data={{
     description: "Gitpod's imprint.",
     title: "Imprint",
-    type: "website",
   }}
 />
 <article class="text-blob">

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -20,7 +20,6 @@
     description:
       "Gitpod streamlines developer workflows by providing prebuilt, collaborative development environments in your browser - powered by VS Code.",
     title: "Gitpod - Always ready to code",
-    type: "website",
   }}
 />
 

--- a/src/routes/pricing.svelte
+++ b/src/routes/pricing.svelte
@@ -16,7 +16,6 @@
     description:
       "Gitpod is free for Open Source, and offers productive features for you, your team and your business at reasonable prices.",
     title: "Pricing",
-    type: "website",
   }}
 />
 <PlansAndPricing />

--- a/src/routes/privacy.svelte
+++ b/src/routes/privacy.svelte
@@ -10,7 +10,6 @@
   data={{
     description: "Gitpod's privacy policy.",
     title: "Privacy",
-    type: "website",
   }}
 />
 <article class="text-blob">

--- a/src/routes/screencasts/index.svelte
+++ b/src/routes/screencasts/index.svelte
@@ -16,7 +16,6 @@
   data={{
     description: "Learn more about Gitpod with these short screencasts.",
     title: "Screencasts",
-    type: "website",
   }}
 />
 

--- a/src/routes/self-hosted.svelte
+++ b/src/routes/self-hosted.svelte
@@ -13,7 +13,6 @@
   data={{
     description: "Self-Host Gitpod on Your Own Infrastructure.",
     title: "Self-Hosted",
-    type: "website",
   }}
 />
 <PlansAndPricing />

--- a/src/routes/terms.svelte
+++ b/src/routes/terms.svelte
@@ -10,7 +10,6 @@
   data={{
     description: "Gitpod's terms of service.",
     title: "Terms",
-    type: "website",
   }}
 />
 <article class="text-blob">

--- a/src/types/open-graph.type.ts
+++ b/src/types/open-graph.type.ts
@@ -3,7 +3,7 @@ export type Type = "article" | "website";
 export type OpenGraph = {
   description: string;
   title: string;
-  type: Type;
+  type?: Type;
   image?: string;
   imageTwitter?: string;
 };


### PR DESCRIPTION
Objective:
Make `<OpenGraph />`'s `type` prop optional and default to `"website"`

Solution: 
Updated TS prop types and made `type` optional and default to "website." Removed all instances of `type: "website"`
