### PR TITLE
Changed border-radius to 0.25rem on smaller screens

### DIFF
--- a/src/components/index/section-screenshot.svelte
+++ b/src/components/index/section-screenshot.svelte
@@ -27,6 +27,7 @@
 
     @media (max-width: 768px) {
       margin-bottom: -20px;
+      border-radius: 0.25rem;
     }
   }
 


### PR DESCRIPTION
As suggested by @gtsiolis, I've updated the `border-radius` property to `0.25rem` on smaller viewports. There is no further cropping of content. 