### PR TITLE
Remove mention of Safari extension

### DIFF
--- a/src/routes/docs/browser-extension.md
+++ b/src/routes/docs/browser-extension.md
@@ -19,7 +19,7 @@ prefixing for you. Nothing more.
 We provide the extension for
 
 - [Chrome](https://chrome.google.com/webstore/detail/gitpod-online-ide/dodmmooeoklaejobgleioelladacbeki)
-- [Firefox](https://addons.mozilla.org/firefox/addon/gitpod/).
+- [Firefox](https://addons.mozilla.org/firefox/addon/gitpod/)
 
 ## Use with Gitpod Self-Hosted
 

--- a/src/routes/docs/getting-started.md
+++ b/src/routes/docs/getting-started.md
@@ -32,7 +32,7 @@ For example, try opening [https://gitpod.io/#https://gitlab.com/gitpod/spring-pe
 
 ## Browser Extension
 
-For convenience, we've made a browser extension that works with Google Chrome, Mozilla Firefox, and Safari. The extension adds a Gitpod button on every project and branch across GitLab, GitHub, and Bitbucket so you can easily open a new workspace for any existing project.
+For convenience, we've made a browser extension that works with Google Chrome and Mozilla Firefox. The extension adds a Gitpod button on every project and branch across GitLab, GitHub, and Bitbucket so you can easily open a new workspace for any existing project.
 
 [Learn more &rarr;](/docs/browser-extension)
 


### PR DESCRIPTION
While reading through the docs as part of my onboarding I noticed that we mention a Safari extension on the [Getting Started page](https://www.gitpod.io/docs/getting-started#browser-extension) but when you click through to the [Browser Extension](https://www.gitpod.io/docs/browser-extension) page it doesn't list Safari.

I removed Safari from the Getting Started page as it looks like it isn't available in the app store. 

Happy to make any other edits you think are appropriate, e.g. we could have a Safari section that on the Browser Extension page that links to https://github.com/gitpod-io/browser-extension#safari in case people want to manually build it ☺️