### PR TITLE
Add more visible attribution for XKCD <3

### DIFF
--- a/src/routes/blog/gitpod-open-source-sustainability-fund.md
+++ b/src/routes/blog/gitpod-open-source-sustainability-fund.md
@@ -86,6 +86,7 @@ Go sign up to <a href="https://github.com/sponsors">GitHub Sponsors</a> or <a hr
 Nadia Eghbal, in 2016 with the support of the Ford Foundation, authored an <a href="https://www.fordfoundation.org/work/learning/research-reports/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/">extensive report</a> into the unseen labour behind our digital infrastructure. She recently published the successor of the report: <a href="https://www.amazon.com.au/Working-Public-Making-Maintenance-Software/dp/0578675862">Working in Public: The Making and Maintenance of Open Source Software</a>. If you haven't read her work before, then start there.
 
 ![Credit: XKCD](../../../static/images/blog/gitpod-open-source-sustainability-fund/xkcd.png)
+_Credit: [XKCD](https://xkcd.com/2347/)_
 
 Eghbal, in her work outlines, digital infrastructure should be treated as a necessary public good. Free public source code makes it exponentially cheaper and easier for companies to build software and makes technology more accessible across the globe. However, there is a common misconception that the labour for open source projects is well-funded. In reality, it is largely created and maintained by volunteers who do it to build their reputations, out of a sense of obligation or simply as a labour of love.
 


### PR DESCRIPTION
Looks like this:

<img width="1440" alt="Screenshot 2021-04-27 at 13 56 07" src="https://user-images.githubusercontent.com/599268/116237405-76659580-a760-11eb-9aa3-ca4c0c429377.png">

https://deploy-preview-415--gitpod-kumquat.netlify.app/blog/gitpod-open-source-sustainability-fund

- Not sure about the italics
- Maybe the credit text should be horizontally centered?
- Maybe the image could also be made a bit smaller? (e.g. with a `<img width="600" ...>`)

Feedback welcome!