### PR TITLE
Fix the relative URLs to the self-hosted installation instructions.

### DIFF
--- a/src/routes/docs/self-hosted/0.3.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.3.0/self-hosted.md
@@ -20,5 +20,5 @@ This infrastructure may be a cloud provider or self-managed Kubernetes. It may b
 Regardless of your target environment, you will need to ensure that the [installation prerequisites](./install/prepare-installation) are available.
 Gitpod can be installed in the following environments:
 
-- [Vanilla Kubernetes](./install/install-on-kubernetes): All you need is a domain and a Kubernetes cluster.
-- [Google Cloud Platform](./install/install-on-gcp-script): Install Gitpod optimised for Google Cloud Platform.
+- [Vanilla Kubernetes](/docs/self-hosted/0.3.0/install/install-on-kubernetes): All you need is a domain and a Kubernetes cluster.
+- [Google Cloud Platform](/docs/self-hosted/0.3.0/install/install-on-gcp-script): Install Gitpod optimised for Google Cloud Platform.

--- a/src/routes/docs/self-hosted/0.4.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.4.0/self-hosted.md
@@ -21,12 +21,12 @@ You can find all configuration templates and installation scripts in this reposi
 
 The easiest way to install Gitpod Self-Hosted is currently on Google Cloud Platform (that's also where [gitpod.io](https://gitpod.io) is deployed). GCP is the recommended platform for most users:
 
-- [Install Gitpod on Google Cloud Platform](./install/install-on-gcp-script)
+- [Install Gitpod on Google Cloud Platform](/docs/self-hosted/0.4.0/install/install-on-gcp-script)
 
 ### Install on any Kubernetes cluster
 
 If you manage your own Kubernetes cluster, please follow this guide:
 
-- [Install Gitpod on self-managed Kubernetes](./install/install-on-kubernetes)
+- [Install Gitpod on self-managed Kubernetes](/docs/self-hosted/0.4.0/install/install-on-kubernetes)
 
 Note: Dedicated installation steps for AWS, Azure, and OpenShift are coming soon.

--- a/src/routes/docs/self-hosted/0.5.0/self-hosted.md
+++ b/src/routes/docs/self-hosted/0.5.0/self-hosted.md
@@ -15,12 +15,12 @@ Gitpod, just as you know it from [gitpod.io](https://gitpod.io), can be deployed
 
 The easiest way to install Gitpod Self-Hosted is currently on Google Cloud Platform (that's also where [gitpod.io](https://gitpod.io) is deployed). GCP is the recommended platform for most users:
 
-- [Install Gitpod on Google Cloud Platform](./install/install-on-gcp-script)
+- [Install Gitpod on Google Cloud Platform](/docs/self-hosted/0.5.0/install/install-on-gcp-script)
 
 ## Install on any Kubernetes cluster
 
 If you manage your own Kubernetes cluster, please follow this guide:
 
-- [Install Gitpod on self-managed Kubernetes](./install/install-on-kubernetes)
+- [Install Gitpod on self-managed Kubernetes](/docs/self-hosted/0.5.0/install/install-on-kubernetes)
 
 Note: Dedicated installation steps for AWS, Azure, and OpenShift are coming soon.

--- a/src/routes/docs/self-hosted/latest/self-hosted.md
+++ b/src/routes/docs/self-hosted/latest/self-hosted.md
@@ -21,18 +21,18 @@ You can find all configuration templates and installation scripts in the Gitpod 
 
 The easiest way to install Gitpod Self-Hosted is currently on Google Cloud Platform (that's also where [gitpod.io](https://gitpod.io) is deployed). GCP is the recommended platform for most users:
 
-- [Install Gitpod on Google Cloud Platform](./install/install-on-gcp-script)
+- [Install Gitpod on Google Cloud Platform](/docs/self-hosted/latest/install/install-on-gcp-script)
 
 ### Install on AWS
 
 Alternatively, Gitpod comes with a setup for AWS that integrates with some AWS resource, like Load Balancers or S3 for storing workspace data:
 
-- [Install Gitpod on AWS](./install/install-on-aws-script)
+- [Install Gitpod on AWS](/docs/self-hosted/latest/install/install-on-aws-script)
 
 ### Install on any Kubernetes cluster
 
 If you already have a Kubernetes cluster, or don't want/cannot use AWS or GCP, please follow the generic guide:
 
-- [Install Gitpod on Kubernetes](./install/install-on-kubernetes)
+- [Install Gitpod on Kubernetes](/docs/self-hosted/latest/install/install-on-kubernetes)
 
 Note: Dedicated installation steps for Azure and OpenShift are on our roadmap.


### PR DESCRIPTION
Close #435 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/436"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

