### PR TITLE
Overlapping button solution

### DIFF
--- a/src/components/banners/announcement.svelte
+++ b/src/components/banners/announcement.svelte
@@ -11,12 +11,13 @@
 </script>
 
 <Banner storageKey="announcement-{announcementDate}" let:closeBanner>
-  <p class="relative flex-1 text-center">
-    📣 DevX Conf - Bring back joy and speed to our workflows. | <a
+  <span class="pr-4 md:pr-6 flex-1 text-lg text-right">📣</span>
+  <p class="relative flex-2">
+    DevX Conf - Bring back joy and speed to our workflows. | <a
       href="https://devxconf.org/">Explore</a
     >
   </p>
-  <button on:click={closeBanner} class="absolute right-0 px-4 py-1 md:px-6"
+  <button on:click={closeBanner} class="pl-4 md:pl-6 flex-1"
     ><svg
       width="16"
       height="16"

--- a/src/components/banners/announcement.svelte
+++ b/src/components/banners/announcement.svelte
@@ -11,13 +11,13 @@
 </script>
 
 <Banner storageKey="announcement-{announcementDate}" let:closeBanner>
-  <span class="pr-4 md:pr-6 flex-1 text-lg text-right">📣</span>
-  <p class="flex-2">
+  <span class="flex-1 text-lg text-right">📣</span>
+  <p class="flex-2 px-4 md:px-6">
     DevX Conf - Bring back joy and speed to our workflows. | <a
       href="https://devxconf.org/">Explore</a
     >
   </p>
-  <button on:click={closeBanner} class="pl-4 md:pl-6 flex-1"
+  <button on:click={closeBanner} class="flex-1"
     ><svg
       width="16"
       height="16"

--- a/src/components/banners/announcement.svelte
+++ b/src/components/banners/announcement.svelte
@@ -12,7 +12,7 @@
 
 <Banner storageKey="announcement-{announcementDate}" let:closeBanner>
   <span class="pr-4 md:pr-6 flex-1 text-lg text-right">📣</span>
-  <p class="relative flex-2">
+  <p class="flex-2">
     DevX Conf - Bring back joy and speed to our workflows. | <a
       href="https://devxconf.org/">Explore</a
     >


### PR DESCRIPTION
Addresses issue #404 

The current layout and styling of the banner made it difficult to find a satisfactory solution. I opted to separate the megaphone emoji and placed it in its own separate `<span>` element. I also changed the `absolute` positioning of the close button to `flex-1`. In fact, the `flex` property is now present on every element in the Announcement banner to help distribute them evenly. This is the result on mobile screen sizes:
![image](https://user-images.githubusercontent.com/58940073/117560944-03112d00-b058-11eb-8c0d-102950a9fc94.png)
This is the result on a desktop:
![image](https://user-images.githubusercontent.com/58940073/117560955-1ae8b100-b058-11eb-8a30-e97048087e78.png)

Don't like it? I'm open to suggestions. 


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

