### PR TITLE
Update link on self-hosted section

### DIFF
--- a/src/contents/pricing.ts
+++ b/src/contents/pricing.ts
@@ -67,8 +67,8 @@ export const otherPlans = [
       "Gitpod self-hosted is the best solution for teams who want to keep full data control or use Gitpod in private networks.",
       "Install Gitpod Self-Hosted on <strong>Google Cloud Platform</strong> and <strong>K3s</strong>.",
     ],
-    btnText: "Enquire now",
-    btnHref: "/contact",
+    btnText: "Learn more",
+    btnHref: "/self-hosted",
   },
   {
     title: "Student",


### PR DESCRIPTION
### Problem to solve

Lately, there's a slight increase on the questions we get from the community about self hosted pricing specifically. Currently, the self-hosted section links to the contact page but most of the times linking to the [self-hosted page](https://www.gitpod.io/self-hosted/) is sufficient.

We do have a self hosted page linked on the footer links but maybe this is not discoverable enough.

Also, the button label (_Enquire now_) is not using simple language for non-English speakers.

See also [relevant discussion](https://gitpod.slack.com/archives/C01KGM9ETU6/p1620980061224500) (internal).

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/451"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

