### PR TITLE
Add the docs beta index page.

### DIFF
--- a/src/components/docs/beta-banner.svelte
+++ b/src/components/docs/beta-banner.svelte
@@ -1,0 +1,10 @@
+<div>
+  <blockquote>
+    <p><strong>Beta Docs</strong></p>
+    Welcome to the next version of the docs 🎉. We are actively working on this page,
+    please<a
+      href="https://github.com/gitpod-io/website/issues/461"
+      target="__self">provide feedback on GitHub</a
+    > 🙏.
+  </blockquote>
+</div>

--- a/src/components/docs/beta-banner.svelte
+++ b/src/components/docs/beta-banner.svelte
@@ -1,10 +1,25 @@
+<script>
+  import { page } from "$app/stores";
+
+  $: isBetaPage = $page.path.startsWith("/docs/beta");
+</script>
+
 <div>
   <blockquote>
-    <p><strong>Beta Docs</strong></p>
-    Welcome to the next version of the docs 🎉. We are actively working on this page,
-    please<a
-      href="https://github.com/gitpod-io/website/issues/461"
-      target="__self">provide feedback on GitHub</a
-    > 🙏.
+    {#if isBetaPage}
+      <p><strong>Beta Docs</strong></p>
+      Welcome to the next version of the docs 🎉. We are actively working on this
+      page, please<a
+        href="https://github.com/gitpod-io/website/issues/461"
+        target="__self">provide feedback on GitHub</a
+      > 🙏.
+    {:else}
+      <p><strong>Heads up!</strong></p>
+      We are writing new docs at<a href="/docs/beta">/docs/beta</a> 🎉. If you
+      have any feedback, we'd love to hear about it in
+      <a href="https://github.com/gitpod-io/website/issues/461"
+        >this GitHub issue</a
+      > 🙏.
+    {/if}
   </blockquote>
 </div>

--- a/src/components/docs/beta-banner.svelte
+++ b/src/components/docs/beta-banner.svelte
@@ -18,7 +18,7 @@
       We are writing new docs at
       <a href="/docs/beta">/docs/beta</a> 🎉. If you have any feedback, we'd
       love to hear about it in
-      <a href="https://github.com/gitpod-io/website/issues/461"
+      <a href="https://github.com/gitpod-io/website/issues/461" target="__self"
         >this GitHub issue</a
       > 🙏.
     {/if}

--- a/src/components/docs/beta-banner.svelte
+++ b/src/components/docs/beta-banner.svelte
@@ -9,14 +9,15 @@
     {#if isBetaPage}
       <p><strong>Beta Docs</strong></p>
       Welcome to the next version of the docs 🎉. We are actively working on this
-      page, please<a
-        href="https://github.com/gitpod-io/website/issues/461"
-        target="__self">provide feedback on GitHub</a
+      page, please
+      <a href="https://github.com/gitpod-io/website/issues/461" target="__self"
+        >provide feedback on GitHub</a
       > 🙏.
     {:else}
       <p><strong>Heads up!</strong></p>
-      We are writing new docs at<a href="/docs/beta">/docs/beta</a> 🎉. If you
-      have any feedback, we'd love to hear about it in
+      We are writing new docs at
+      <a href="/docs/beta">/docs/beta</a> 🎉. If you have any feedback, we'd
+      love to hear about it in
       <a href="https://github.com/gitpod-io/website/issues/461"
         >this GitHub issue</a
       > 🙏.

--- a/src/components/docs/docs-content-layout.svelte
+++ b/src/components/docs/docs-content-layout.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { page } from "$app/stores";
+  import BetaBanner from "./beta-banner.svelte";
   import OpenGraph from "../open-graph.svelte";
   import docsCurrentSectionStore from "../../stores/docs-current-section";
 
@@ -6,11 +8,8 @@
   export let title;
 
   $: $docsCurrentSectionStore = section;
+  $: isBetaPage = $page.path.startsWith("/docs/beta");
 </script>
-
-<!-- <style lang="scss" global>
-  @import "../../assets/docs";
-</style> -->
 
 <OpenGraph
   data={{
@@ -20,5 +19,8 @@
   }}
 />
 <div class="content-docs">
+  {#if isBetaPage}
+    <BetaBanner />
+  {/if}
   <slot />
 </div>

--- a/src/components/docs/docs-content-layout.svelte
+++ b/src/components/docs/docs-content-layout.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { page } from "$app/stores";
   import BetaBanner from "./beta-banner.svelte";
   import OpenGraph from "../open-graph.svelte";
   import docsCurrentSectionStore from "../../stores/docs-current-section";
@@ -8,7 +7,6 @@
   export let title;
 
   $: $docsCurrentSectionStore = section;
-  $: isBetaPage = $page.path.startsWith("/docs/beta");
 </script>
 
 <OpenGraph
@@ -19,8 +17,6 @@
   }}
 />
 <div class="content-docs">
-  {#if isBetaPage}
-    <BetaBanner />
-  {/if}
+  <BetaBanner />
   <slot />
 </div>

--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -100,6 +100,7 @@
       M("Create a Team", "teams"),
     ]),
     M("Changelog", "changelog"),
+    M("🚧 Beta Docs", "beta"),
   ];
 </script>
 

--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import Menu from "../../components/docs/menu.svelte";
   import MobileMenu from "../../components/docs/mobile-menu/index.svelte";
   import Search from "../../components/docs/search.svelte";
   import "../../assets/docs.scss";
+
+  $: isBetaPage = $page.path.startsWith("/docs/beta");
 
   // This file is used to define entries in the side menu
   interface MenuEntry {
@@ -19,89 +22,95 @@
     };
   }
 
-  const MENU: MenuEntry[] = [
-    M("Introduction", ""),
-    M("Getting Started", "getting-started", [
-      M("Example Projects", "examples"),
-    ]),
-    M("Workspaces", "workspaces", [
-      M("Context URLs", "context-urls"),
-      M("Life of a Workspace", "life-of-workspace"),
-      M("Collaboration & Sharing", "sharing-and-collaboration"),
-      M("Command Line Interface", "command-line-interface"),
-    ]),
-    M("Configure Your Project", "configuration", [
-      M(".gitpod.yml", "config-gitpod-file"),
-      M("Docker Configuration", "config-docker"),
-      M("Start Tasks", "config-start-tasks"),
-      M("VS Code Extensions", "vscode-extensions"),
-      M("Exposing Ports", "config-ports"),
-      M("Prebuilt Workspaces", "prebuilds"),
-      M("Environment Variables", "environment-variables"),
-      M("Workspace Location", "checkout-location"),
-      M("Editor Configuration", "config-editor"),
-    ]),
-    M("Integrations", "integrations", [
-      M("GitLab Integration", "gitlab-integration"),
-      M("GitHub Integration", "github-integration"),
-      M("Bitbucket Integration", "bitbucket-integration"),
-      M("Browser Extension", "browser-extension"),
-    ]),
-    M("Languages & Frameworks", "languages-and-frameworks", [
-      M("JavaScript", "languages/javascript"),
-      M("Python", "languages/python"),
-      M("HTML/CSS", "languages/html"),
-      M("Java", "languages/java"),
-      M("C++", "languages/cpp"),
-      M("Go", "languages/go"),
-      M("Bash", "languages/bash"),
-      M("Ruby", "languages/ruby"),
-      M("PHP", "languages/php"),
-      M("Vue", "languages/vue"),
-      M("Svelte", "languages/svelte"),
-      M("Scala", "languages/scala"),
-      M("Rust", "languages/rust"),
-      M(".NET", "languages/dotnet"),
-      M("Dart", "languages/dart"),
-      M("Julia", "languages/julia"),
-      M("LaTeX", "languages/latex"),
-      M("R", "languages/r"),
-      M("Kotlin", "languages/kotlin"),
-      M("Pandas", "languages/python#pandas"),
-      M("Deno", "languages/deno"),
-    ]),
-    // M("Feature Preview", "feature-preview"),
-    M("Gitpod Self-Hosted", "self-hosted/latest/self-hosted", [
-      M(
-        "Install on Google Cloud Platform",
-        "self-hosted/latest/install/install-on-gcp-script"
-      ),
-      M(
-        "Install on Amazon Web Services",
-        "self-hosted/latest/install/install-on-aws-script"
-      ),
-      M(
-        "Install on self-managed Kubernetes",
-        "self-hosted/latest/install/install-on-kubernetes"
-      ),
-      M("Configure Ingress", "self-hosted/latest/install/configure-ingress"),
-      M("Configure OAuth", "self-hosted/latest/install/oauth"),
-      M("Configure a Database", "self-hosted/latest/install/database"),
-      M(
-        "Configure a Docker Registry",
-        "self-hosted/latest/install/docker-registry"
-      ),
-      M("Configure Storage", "self-hosted/latest/install/storage"),
-      M("Configure Nodes", "self-hosted/latest/install/nodes"),
-      M("Configure Workspaces", "self-hosted/latest/install/workspaces"),
-    ]),
-    M("Subscriptions", "subscriptions", [
-      M("Professional Open Source", "professional-open-source"),
-      M("Create a Team", "teams"),
-    ]),
-    M("Changelog", "changelog"),
-    M("🚧 Beta Docs", "beta"),
-  ];
+  let MENU: MenuEntry[];
+  $: MENU = isBetaPage
+    ? [M("Getting Started", "beta"), M("Stable Docs", "")]
+    : [
+        M("Introduction", ""),
+        M("Getting Started", "getting-started", [
+          M("Example Projects", "examples"),
+        ]),
+        M("Workspaces", "workspaces", [
+          M("Context URLs", "context-urls"),
+          M("Life of a Workspace", "life-of-workspace"),
+          M("Collaboration & Sharing", "sharing-and-collaboration"),
+          M("Command Line Interface", "command-line-interface"),
+        ]),
+        M("Configure Your Project", "configuration", [
+          M(".gitpod.yml", "config-gitpod-file"),
+          M("Docker Configuration", "config-docker"),
+          M("Start Tasks", "config-start-tasks"),
+          M("VS Code Extensions", "vscode-extensions"),
+          M("Exposing Ports", "config-ports"),
+          M("Prebuilt Workspaces", "prebuilds"),
+          M("Environment Variables", "environment-variables"),
+          M("Workspace Location", "checkout-location"),
+          M("Editor Configuration", "config-editor"),
+        ]),
+        M("Integrations", "integrations", [
+          M("GitLab Integration", "gitlab-integration"),
+          M("GitHub Integration", "github-integration"),
+          M("Bitbucket Integration", "bitbucket-integration"),
+          M("Browser Extension", "browser-extension"),
+        ]),
+        M("Languages & Frameworks", "languages-and-frameworks", [
+          M("JavaScript", "languages/javascript"),
+          M("Python", "languages/python"),
+          M("HTML/CSS", "languages/html"),
+          M("Java", "languages/java"),
+          M("C++", "languages/cpp"),
+          M("Go", "languages/go"),
+          M("Bash", "languages/bash"),
+          M("Ruby", "languages/ruby"),
+          M("PHP", "languages/php"),
+          M("Vue", "languages/vue"),
+          M("Svelte", "languages/svelte"),
+          M("Scala", "languages/scala"),
+          M("Rust", "languages/rust"),
+          M(".NET", "languages/dotnet"),
+          M("Dart", "languages/dart"),
+          M("Julia", "languages/julia"),
+          M("LaTeX", "languages/latex"),
+          M("R", "languages/r"),
+          M("Kotlin", "languages/kotlin"),
+          M("Pandas", "languages/python#pandas"),
+          M("Deno", "languages/deno"),
+        ]),
+        // M("Feature Preview", "feature-preview"),
+        M("Gitpod Self-Hosted", "self-hosted/latest/self-hosted", [
+          M(
+            "Install on Google Cloud Platform",
+            "self-hosted/latest/install/install-on-gcp-script"
+          ),
+          M(
+            "Install on Amazon Web Services",
+            "self-hosted/latest/install/install-on-aws-script"
+          ),
+          M(
+            "Install on self-managed Kubernetes",
+            "self-hosted/latest/install/install-on-kubernetes"
+          ),
+          M(
+            "Configure Ingress",
+            "self-hosted/latest/install/configure-ingress"
+          ),
+          M("Configure OAuth", "self-hosted/latest/install/oauth"),
+          M("Configure a Database", "self-hosted/latest/install/database"),
+          M(
+            "Configure a Docker Registry",
+            "self-hosted/latest/install/docker-registry"
+          ),
+          M("Configure Storage", "self-hosted/latest/install/storage"),
+          M("Configure Nodes", "self-hosted/latest/install/nodes"),
+          M("Configure Workspaces", "self-hosted/latest/install/workspaces"),
+        ]),
+        M("Subscriptions", "subscriptions", [
+          M("Professional Open Source", "professional-open-source"),
+          M("Create a Team", "teams"),
+        ]),
+        M("Changelog", "changelog"),
+        M("🚧 Beta Docs", "beta"),
+      ];
 </script>
 
 <style>

--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -24,7 +24,7 @@
 
   let MENU: MenuEntry[];
   $: MENU = isBetaPage
-    ? [M("Getting Started", "beta"), M("Stable Docs", "")]
+    ? [M("Getting Started", "beta"), M("🔙 Go back to stable docs", "")]
     : [
         M("Introduction", ""),
         M("Getting Started", "getting-started", [

--- a/src/routes/docs/beta/index.md
+++ b/src/routes/docs/beta/index.md
@@ -1,0 +1,9 @@
+<script context="module">
+  export const prerender = true;
+</script>
+
+# Introduction to Gitpod (beta)
+
+Welcome 👋! You arrived here a bit early as we are currently (May 2021) in the process of rewriting the Gitpod documentation.
+
+Please head over to https://github.com/gitpod-io/website/issues/461 if you'd like to provide any feedback - we'd love to hear from you 🙏.


### PR DESCRIPTION
Relates to #461.

This PR adds:
* a placeholder `/docs/beta` page
* a banner on old and new docs pages to let readers know we are actively working on new docs
* a docs navigation for the beta docs

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/462"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

