### PR TITLE
footer add the missing blog link.

### DIFF
--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -38,6 +38,7 @@
         <li>Developer</li>
         <li><a href="/#get-started">Getting started</a></li>
         <li><a href="/screencasts">Screencasts</a></li>
+        <li><a href="/blog">Blog</a></li>
         <li><a href="/docs">Documentation</a></li>
         <li>
           <a


### PR DESCRIPTION
Fixes #302

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

