### PR TITLE
[screencasts]: fix the thumnail overflowing text issue + general layout updates.

### DIFF
--- a/src/assets/scss/_screencasts.scss
+++ b/src/assets/scss/_screencasts.scss
@@ -56,7 +56,8 @@
 .cast > div > * {
   flex: 0 0 auto;
 }
-.cast h2 {
+.cast h2,
+.cast .h2 {
   flex: 1;
   margin: 0;
   font-size: var(--xx-small);

--- a/src/components/screencasts/preview.svelte
+++ b/src/components/screencasts/preview.svelte
@@ -14,12 +14,12 @@
 
 <a
   href="/screencasts/{screencast.title.toLowerCase().replace(/\s/g, '-')}"
-  class="cast"
+  class="cast min-w-full"
 >
   <div>
     <data>Screencast {screencastNumberPadded}</data>
     {#if headlineOrder === "h3"}
-      <h3>{screencast.title}</h3>
+      <h3 class="h2">{screencast.title}</h3>
     {:else}
       <h2>{screencast.title}</h2>
     {/if}

--- a/src/components/youtube-embed.svelte
+++ b/src/components/youtube-embed.svelte
@@ -8,8 +8,8 @@
     position: relative;
     overflow: hidden;
     max-width: 100%;
-    max-height: 315px;
-    width: 560px;
+    max-height: 500px;
+    width: 880px;
     margin: auto;
   }
 

--- a/src/routes/screencasts/[title].svelte
+++ b/src/routes/screencasts/[title].svelte
@@ -21,9 +21,13 @@
   .related {
     margin: 2rem auto;
   }
+
+  .header {
+    @apply mb-small;
+  }
 </style>
 
-<header>
+<header class="header">
   <h1>{screencast.title}</h1>
   <p>{screencast.description}</p>
 </header>
@@ -44,8 +48,8 @@
 </p>
 
 {#if screencast.nextScreencast}
-  <div class="screencasts">
-    <h2>Next up...</h2>
+  <div class="max-w-sm my-medium mx-auto">
+    <h2 class="text-center mb-small">Next up...</h2>
     <ScreencastPreview
       screencast={screencasts[screencast.nextScreencast]}
       screencastNumber={screencast.nextScreencast}


### PR DESCRIPTION
Fixes #499 

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/119866585-634c0e00-bf36-11eb-8953-3d6ca2bc8f64.png)


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/501"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

