### PR TITLE
Remove the "Go back to stable docs" menu item.

### DIFF
--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -82,7 +82,6 @@
       M("Roadmap", "references/roadmap"),
       // M("Changelog", "references/changelog"),
     ]),
-    M("🔙 Go back to stable docs", ""),
   ];
   const MENU_v1 = [
     M("Introduction", ""),


### PR DESCRIPTION
Relates to #464