### PR TITLE
fix the edit in gitpod button.

### DIFF
--- a/src/components/docs/edit-in-gitpod.svelte
+++ b/src/components/docs/edit-in-gitpod.svelte
@@ -15,6 +15,7 @@
   }
 
   .btn-otherbrand {
+    display: inline-flex !important;
     @apply rounded-2xl text-btn-small px-micro;
   }
 


### PR DESCRIPTION
Fixes #540 

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/120475147-6e81bc80-c3c2-11eb-9385-a7e0dac3f167.png)


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/541"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

