### PR TITLE
SEO: Redirect /docs/configuration to /docs/configure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -117,6 +117,11 @@
   status = 301
 
 [[redirects]]
+  from = "/docs/configuration"
+  to = "/docs/configure"
+  status = 301
+
+[[redirects]]
   from = "/docs/40_Configuration"
   to = "/docs/configure"
   status = 301


### PR DESCRIPTION


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/572"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

