### PR TITLE
Remove the trailing slash from URLs.

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,6 +42,11 @@ export const handle: import("@sveltejs/kit").Handle = async ({
   request,
   render,
 }) => {
+  if (request.path.endsWith("/")) {
+    // Fix for https://github.com/gitpod-io/website/issues/552 until we
+    // upgrade SvelteKit to at least 1.0.0-next.105
+    request.path = request.path.substring(0, request.path.length - 1);
+  }
   const response = await render(request);
 
   return {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,7 +42,7 @@ export const handle: import("@sveltejs/kit").Handle = async ({
   request,
   render,
 }) => {
-  if (request.path.endsWith("/")) {
+  if (request.path !== "/" && request.path.endsWith("/")) {
     // Fix for https://github.com/gitpod-io/website/issues/552 until we
     // upgrade SvelteKit to at least 1.0.0-next.105
     request.path = request.path.substring(0, request.path.length - 1);


### PR DESCRIPTION
Close #552.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/575"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

