### PR TITLE
Fixed typos & replaced example with template

### DIFF
--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -23,11 +23,12 @@
   const MENU: MenuEntry[] = [
     M("Introduction", ""),
     M("Quickstart", "quickstart", [
-      M("Node or TypeScript example", "quickstart/typescript"),
-      M("Go example", "quickstart/go"),
-      M("Rust example", "quickstart/rust"),
-      M("Java example", "quickstart/java"),
-      M("Svelte example", "quickstart/svelte"),
+      M("Node/TypeScript", "quickstart/typescript"),
+      M("Python Django", "quickstart/python"),
+      M("Go", "quickstart/go"),
+      M("Rust", "quickstart/rust"),
+      M("Java Spring", "quickstart/java"),
+      M("Svelte", "quickstart/svelte"),
     ]),
     M("Getting Started", "getting-started"),
     M("Configure", "configure", [

--- a/src/routes/docs/quickstart/go.md
+++ b/src/routes/docs/quickstart/go.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Go example
+title: Go template
 ---
 
 <script context="module">
@@ -9,7 +9,7 @@ title: Go example
 
 # Go Quickstart
 
-Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Go](https://github.com/gitpod-io/example-golang-cli) example.
+Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Go](https://github.com/gitpod-io/example-golang-cli) template.
 
 The following guide will:
 
@@ -22,6 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [Go template](https://github.com/gitpod-io/example-golang-cli/generate).
+- Name it e.g. `my-go-example`.
 
 ### Step 2: Install Gitpod app
 

--- a/src/routes/docs/quickstart/index.md
+++ b/src/routes/docs/quickstart/index.md
@@ -9,14 +9,14 @@ title: Quickstart
 
 # Quickstart
 
-Learn how to start using Gitpod on an example project that is hosted on GitHub in less than 5 minutes. For simplicity we use GitHub as the git hoster but the steps outlined work equally well for GitLab and Bitbucket. This section helps you understand the features and advantages of Gitpod in a learning environment based on the [Gitpod example](/docs/examples) projects. The example projects are pre-configured to use Gitpod:
+Learn how to start using Gitpod on an example project that is hosted on GitHub in less than 5 minutes. For simplicity we use GitHub as the git hoster but the steps outlined work equally well for GitLab and Bitbucket. This section helps you understand the features and advantages of Gitpod in a learning environment. All templates are pre-configured to use Gitpod and ready-to-code:
 
-- [Node or TypeScript example](/docs/quickstart/typescript)
-- [Python example](/docs/quickstart/python)
-- [Go example](/docs/quickstart/go)
-- [Rust example](/docs/quickstart/rust)
-- [Java example](/docs/quickstart/java)
-- [Svelte example](/docs/quickstart/svelte)
+- [Node/TypeScript template](/docs/quickstart/typescript)
+- [Python Django template](/docs/quickstart/python)
+- [Go template](/docs/quickstart/go)
+- [Rust template](/docs/quickstart/rust)
+- [Java Spring template](/docs/quickstart/java)
+- [Svelte template](/docs/quickstart/svelte)
 
 ## Installing the Gitpod browser extension
 

--- a/src/routes/docs/quickstart/java.md
+++ b/src/routes/docs/quickstart/java.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Java example
+title: Java template
 ---
 
 <script context="module">
@@ -9,7 +9,7 @@ title: Java example
 
 # Java Quickstart
 
-Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Java](https://github.com/gitpod-io/spring-petclinic) example.
+Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Java Spring](https://github.com/gitpod-io/spring-petclinic) template.
 
 The following guide will:
 
@@ -22,6 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [Java template](https://github.com/gitpod-io/spring-petclinic/generate).
+- Name it e.g. `my-java-template`.
 
 ### Step 2: Install Gitpod app
 

--- a/src/routes/docs/quickstart/python.md
+++ b/src/routes/docs/quickstart/python.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Python example
+title: Python template
 ---
 
 <script context="module">
@@ -9,7 +9,7 @@ title: Python example
 
 # Python Django Quickstart
 
-Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Go](https://github.com/gitpod-io/example-python-django) example.
+Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [Python](https://github.com/gitpod-io/example-python-django) template.
 
 The following guide will:
 
@@ -22,7 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [Python template](https://github.com/gitpod-io/example-python-django/generate).
-- Name it e.g. `my-python-example`.
+- Name it e.g. `my-python-template`.
 
 ### Step 2: Install the Gitpod app
 

--- a/src/routes/docs/quickstart/rust.md
+++ b/src/routes/docs/quickstart/rust.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Rust example
+title: Rust template
 ---
 
 <script context="module">
@@ -22,6 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [Rust template](https://github.com/gitpod-io/example-rust-cli/generate).
+- Name it e.g. `my-rust-template`.
 
 ### Step 2: Install Gitpod app
 

--- a/src/routes/docs/quickstart/svelte.md
+++ b/src/routes/docs/quickstart/svelte.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Svelte example
+title: Svelte template
 ---
 
 <script context="module">
@@ -22,6 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [SvelteJS template](https://github.com/gitpod-io/sveltejs-template/generate).
+- Name it e.g. `my-svelte-template`.
 
 ### Step 2: Install Gitpod app
 

--- a/src/routes/docs/quickstart/typescript.md
+++ b/src/routes/docs/quickstart/typescript.md
@@ -1,6 +1,6 @@
 ---
 section: quickstart
-title: Node/TypeScript example
+title: Node/TypeScript template
 ---
 
 <script context="module">
@@ -22,6 +22,7 @@ For simplicity we use a GitHub template, but Gitpod works similiarly with GitLab
 ### Step 1: Clone Git repository
 
 - Create a new repository based on the [Node/TypeScript template](https://github.com/gitpod-io/example-typescript-node/generate).
+- Name it e.g. `my-typescript-template`.
 
 ### Step 2: Install Gitpod app
 


### PR DESCRIPTION
Added the Python Django template to the menu and replaced the word example with template. 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/588"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

