### PR TITLE
[docs] remove mention of gitpod.yml reference

### DIFF
--- a/src/routes/docs/config-gitpod-file.md
+++ b/src/routes/docs/config-gitpod-file.md
@@ -22,8 +22,6 @@ ports:
     onOpen: open-preview
 ```
 
-Please refer to the [`.gitpod.yml` reference](/docs/config-gitpod-file) for a list of all available configuration options and their meaning.
-
 ## How to provide the .gitpod.yml config file
 
 In order to tell Gitpod how to prepare a dev environment for your project, you check in a `.gitpod.yml` file into the root of your repository. This way you can


### PR DESCRIPTION
the link points to itself and confuses users, as they think there is some
reference somewhere that they cannnot find.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

