### PR TITLE
fixes #156 - disable submit button on init & validate inputs on lost …

### DIFF
--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -59,35 +59,38 @@
       el: null,
       valid: false,
       checked: false,
+      dirty: false,
     },
     email: {
       el: null,
       valid: false,
       value: "",
+      dirty: false,
     },
     message: {
       el: null,
       valid: false,
       value: "",
+      dirty: false,
     },
     name: {
       el: null,
       valid: false,
       value: "",
+      dirty: false,
     },
     selectedSubject: {
       el: null,
       valid: false,
       value: "",
+      dirty: false,
     },
   };
-  let isFormDirty = false;
   let isEmailSent = false;
 
   $: isFormValid = Object.values(formData).every((field) => field.valid);
 
   const handleSubmit = async () => {
-    isFormDirty = true;
     if (!isFormValid) {
       return;
     }
@@ -139,6 +142,14 @@
   fieldset li {
     margin: 0 1rem 0 0;
   }
+  .btn {
+    background-color: var(--brand-almost-ripe);
+  }
+  .btn:disabled {
+    background-color: var(--sand-dark);
+    color: var(--dark-gray);
+    cursor: default;
+  }
 </style>
 
 <OpenGraph
@@ -169,21 +180,23 @@
     <form on:submit|preventDefault={handleSubmit} novalidate>
       <h2 class="h3 text-center mb-8">Send us a message</h2>
       <ul>
-        <li class:error={isFormDirty && !formData.name.valid}>
+        <li class:error={formData.name.dirty && !formData.name.valid}>
           <label for="name">Name*</label>
           <input
             id="name"
             bind:value={formData.name.value}
             bind:this={formData.name.el}
-            on:change={() => {
+            on:keyup={() => {
               formData.name.valid =
                 formData.name.value && formData.name.el.checkValidity();
+              formData.name.dirty = true;
             }}
+            on:blur={() => (formData.name.dirty = true)}
             type="text"
             autocomplete="name"
           />
         </li>
-        <li class:error={isFormDirty && !formData.email.valid}>
+        <li class:error={formData.email.dirty && !formData.email.valid}>
           <label for="email"
             >E-Mail*
             {#if isStudentEmailNoteShown}
@@ -194,15 +207,19 @@
             id="email"
             bind:value={formData.email.value}
             bind:this={formData.email.el}
-            on:change={() => {
+            on:keyup={() => {
               formData.email.valid =
                 formData.email.value && formData.email.el.checkValidity();
             }}
+            on:blur={() => (formData.email.dirty = true)}
             type="email"
             autocomplete="email"
           />
         </li>
-        <li class:error={isFormDirty && !formData.selectedSubject.valid}>
+        <li
+          class:error={formData.selectedSubject.dirty &&
+            !formData.selectedSubject.valid}
+        >
           <fieldset>
             <legend>Please choose a subject</legend>
             <ul>
@@ -218,6 +235,7 @@
                         formData.selectedSubject.value &&
                         formData.selectedSubject.el.validity.valid;
                     }}
+                    on:blur={() => (formData.selectedSubject.dirty = true)}
                     value={subject}
                     name="subject"
                   />
@@ -229,21 +247,23 @@
             </ul>
           </fieldset>
         </li>
-        <li class:error={isFormDirty && !formData.message.valid}>
+        <li class:error={formData.message.dirty && !formData.message.valid}>
           <label for="message">Your message*</label>
           <textarea
             id="message"
             bind:value={formData.message.value}
             bind:this={formData.message.el}
-            on:change={() => {
+            on:keyup={() => {
               formData.message.valid =
                 formData.message.value && formData.message.el.validity.valid;
+              formData.message.dirty = true;
             }}
+            on:blur={() => (formData.message.dirty = true)}
             cols="30"
             rows="10"
           />
         </li>
-        <li class:error={isFormDirty && !formData.consent.valid}>
+        <li class:error={formData.consent.dirty && !formData.consent.valid}>
           <input
             id="consent"
             bind:checked={formData.consent.checked}
@@ -251,7 +271,9 @@
             on:change={() => {
               formData.consent.valid =
                 formData.consent.checked && formData.consent.el.validity.valid;
+              formData.consent.dirty = true;
             }}
+            on:blur={() => (formData.consent.dirty = true)}
             type="checkbox"
           />
           <label for="consent"
@@ -260,10 +282,8 @@
           >
         </li>
         <li>
-          <button
-            type="submit"
-            class="btn"
-            disabled={isFormDirty && !isFormValid}>Send message</button
+          <button type="submit" class="btn" disabled={!isFormValid}
+            >Send message</button
           >
         </li>
       </ul>

--- a/src/types/form.type.ts
+++ b/src/types/form.type.ts
@@ -1,6 +1,7 @@
 type Field = {
   el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
   valid: boolean;
+  dirty?: boolean;
   value?: string;
   checked?: boolean;
   selected?: string[];


### PR DESCRIPTION
- copied style from [src/assets/scss/_forms.scss](https://github.com/gitpod-io/website/blob/main/src/assets/scss/_forms.scss#L102)  
  should be applied to every btn if that's the desired behaviour
- added  an optional `dirty` property to [src/types/form.type.ts](https://github.com/gitpod-io/website/blob/main/src/types/form.type.ts) to signal that the field has been modified or the user went thru it (onblur event)  
  the `Form` type is also used in [enterprise-license.svelte](https://github.com/gitpod-io/website/blob/main/src/routes/enterprise-license.svelte) and [extension-uninstall.svelte](https://github.com/gitpod-io/website/blob/main/src/routes/extension-uninstall.svelte), if this is the desired behaviour for every form they should also be updated
- the `isFormDirty` variable was no longer neccesary
- errors are shown as-you-type, not only on lost focus, hence the use on `on:keyup` event instead of `on:change`
- errors are shown even before the input looses focus if the user has pressed any key, that's why I also set the `dirty` flag on the `on:keyup` event
- if there were to be many more forms, most part of this could be encapsulated in a reusable action

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/618"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

