### PR TITLE
fixes 544 - left navbar selected entry inconsistency

### DIFF
--- a/src/components/docs/menu-section.svelte
+++ b/src/components/docs/menu-section.svelte
@@ -10,7 +10,7 @@
           ? $docsCurrentSectionStore.replace(/\d\.\d\.\d/, "latest")
           : $docsCurrentSectionStore
       ) >= 0
-    : /\/docs\/$/.test(menuItem.path);
+    : /\/docs\/?$/.test(menuItem.path);
 </script>
 
 <style lang="scss">
@@ -41,7 +41,10 @@
 </style>
 
 <li class="menu-item">
-  <div class:isActiveSection class="menu-container">
+  <div
+    class:isActiveSection={isActiveSection && menuItem.subMenu}
+    class="menu-container"
+  >
     <MenuLink href={menuItem.path} class="text-large">{menuItem.title}</MenuLink
     >
     {#if menuItem.subMenu && isActiveSection}


### PR DESCRIPTION
The problem was that the original regex `/\/docs\/$/.test(menuItem.path)` (see [here](https://github.com/gitpod-io/website/blob/main/src/components/docs/menu-section.svelte#L13)) required a trailing slash to match, so `https://www.gitpod.io/docs` didn't match and `isActiveSection` was false for the Introduction docs page. Making the trailing slash optional with `/\/docs\/?$/.test(menuItem.path)` solved the issue:

![image](https://user-images.githubusercontent.com/481687/121849169-6595c280-ccc1-11eb-9693-0a69606456b7.png)

To implement the b) option (never use white bubble if it's a menu item with no subitems) I added the following condition:

```svelte
  <div
    class:isActiveSection={isActiveSection && menuItem.subMenu}
    class="menu-container"
  >
```

Which yields this result:

![image](https://user-images.githubusercontent.com/481687/121849258-8231fa80-ccc1-11eb-81f2-a53b591e818e.png)

Personally I prefer the a) option, I find it more clear, consistent and better looking. To go that way just leave that line like it currently is (see [here](https://github.com/gitpod-io/website/blob/main/src/components/docs/menu-section.svelte#L44))

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/624"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

