### PR TITLE
fixes #209 - modals a11y

### DIFF
--- a/src/components/modal.svelte
+++ b/src/components/modal.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, tick } from "svelte";
 
   export let isOpen = false;
 
   const dispatch = createEventDispatcher();
 
-  const closeModal = () => {
+  let closeEl: HTMLButtonElement;
+  let focusedEl: HTMLElement;
+
+  $: if (isOpen) {
+    if (typeof document !== "undefined")
+      focusedEl = <HTMLElement>document.activeElement;
+    closeEl && closeEl.focus();
+  }
+
+  const closeModal = async () => {
     dispatch("close");
+    await tick();
+    focusedEl && focusedEl.focus();
+    focusedEl = null;
   };
 
   const handleKeydown = (event: KeyboardEvent) => {
@@ -21,7 +33,10 @@
 {#if isOpen}
   <div class="modal" on:click={closeModal}>
     <div class="content text-blob" on:click={(e) => e.stopPropagation()}>
-      <button aria-label="close this popup" on:click={closeModal}
+      <button
+        bind:this={closeEl}
+        aria-label="close this popup"
+        on:click={closeModal}
         ><img alt="Close" role="presentation" src="/x.svg" /></button
       >
       <slot />

--- a/src/components/modal.svelte
+++ b/src/components/modal.svelte
@@ -14,9 +14,8 @@
     closeEl && closeEl.focus();
   }
 
-  const closeModal = async () => {
+  const closeModal = () => {
     dispatch("close");
-    await tick();
     focusedEl && focusedEl.focus();
     focusedEl = null;
   };

--- a/src/routes/careers.svelte
+++ b/src/routes/careers.svelte
@@ -14,12 +14,12 @@
 
   $: if (selectedCareer) {
     window.location.hash = `#${hyphenate(selectedCareer.title)}`;
+    selectedCareer.focusEl && selectedCareer.focusEl.focus();
   }
 
   onMount(() => {
     const hash = window.location.hash.substring(1);
-    const career = careers.find((career) => hyphenate(career.title) === hash);
-    selectedCareer = career;
+    selectedCareer = careers.find((career) => hyphenate(career.title) === hash);
   });
 </script>
 
@@ -170,6 +170,7 @@
       {#each careers as career}
         <li id={hyphenate(career.title)}>
           <button
+            bind:this={career.focusEl}
             on:click={() => {
               selectedCareer = career;
             }}


### PR DESCRIPTION
This ended up being a bit more tricky than expected.

in components/modal.svelte had to:
- create a `closeEl` variable to give focus to the close button when isOpen is true
- create a `focusEl` variable to save the element which had focus before opening the modal
- return focus to `focusEl` after issuing `dispatch("close")`, and put an `await tick()` to give time for the popup to disappear

and in routes/careers.svelte had to:
- add a `focusEl` property to each career
- bind each career button to the `focusEl` property to set the focus to the career
- when `selectedCareer` is set, make sure the career gets focus

Everything seems to work fine now, even with the keyboard

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/629"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

