### PR TITLE
fixes #628 - renamed job.types.ts to career.type.ts

### DIFF
--- a/src/types/career.type.ts
+++ b/src/types/career.type.ts
@@ -3,7 +3,7 @@ type Listing = {
   items: string[];
 };
 
-export type Job = {
+export type Career = {
   title: string;
   intro: string;
   paragraphs: string;


### PR DESCRIPTION
Just had to rename job.types.ts to career.types.ts. job.types wasn't used anyway.
With this change svelte-check reported errors went down from 53 to 47

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/630"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

