### PR TITLE
Do not insert new rows to the feedback spreadsheet.

### DIFF
--- a/src/functions/feedback.ts
+++ b/src/functions/feedback.ts
@@ -27,10 +27,12 @@ async function saveFeedbackInSheet(feedback: Feedback): Promise<boolean> {
     });
     await doc.loadInfo();
     const sheet = doc.sheetsByTitle["Raw Feedback"];
-    await sheet.addRow(
-      [new Date(), feedback.emotion, feedback.url, feedback.note],
-      { insert: true }
-    );
+    await sheet.addRow([
+      new Date(),
+      feedback.emotion,
+      feedback.url,
+      feedback.note,
+    ]);
     return true;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
Fixes an issue with post-processing of docs feedback.

Inserting new rows caused formulas to not include these new rows.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/631"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

