### PR TITLE
fix(redirect): Gitpod's roadmap is now on GitHub

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,7 +23,7 @@
 
 [[redirects]]
   from = "/roadmap"
-  to = "https://www.notion.so/gitpod/Product-Roadmap-b9b5eac0a15147ac8d2dd25cf0519203"
+  to = "https://github.com/gitpod-io/roadmap"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

