### PR TITLE
[about]: align Gitpod in the news logos to center on mobile.

### DIFF
--- a/src/assets/scss/_team.scss
+++ b/src/assets/scss/_team.scss
@@ -28,11 +28,6 @@
   border-radius: 0.75rem;
   background: var(--brand-light);
 }
-.cardlike {
-  display: flex;
-  flex-flow: row wrap;
-  margin-top: 2rem;
-}
 .cardlike li {
   padding: 1rem;
   flex: 0 0 50%;

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -245,7 +245,7 @@
 
 <div class="redirector header">
   <h2>Gitpod in the news</h2>
-  <ul class="cardlike">
+  <ul class="cardlike flex flex-row flex-wrap justify-center mt-x-small">
     <li>
       <a
         href="https://www.theregister.com/2020/08/25/gitpod_open_sources_cloud_development_platform/"


### PR DESCRIPTION
Fixes #636


This is how they look now:

![image](https://user-images.githubusercontent.com/46004116/122618324-7c645c80-d0a7-11eb-88d0-b46e6a2c3632.png)


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/645"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

