### PR TITLE
fix(blog): windows download links

### DIFF
--- a/src/routes/blog/local-app.md
+++ b/src/routes/blog/local-app.md
@@ -45,19 +45,21 @@ To get started, download the preview release of the _Gitpod Local Companion_ app
 
 - [Mac](https://gitpod.io/static/bin/gitpod-local-companion-darwin) - you will need to grant permission as it is not yet notarised. See ["open an app that hasn’t been notarised or is from an unidentified developer"](https://support.apple.com/en-au/HT202491) or click on the app in Finder while holding the Control key down and select 'Open' from the menu and then 'Open' in the prompt.
 - [Linux](https://gitpod.io/static/bin/gitpod-local-companion-linux)
-- [Windows](https://gitpod.io/static/bin/gitpod-local-companion-windows)
+- [Windows](https://gitpod.io/static/bin/gitpod-local-companion-windows.exe)
 
 Alternatively, in a terminal run the following:
 
 ```shell
   # mac
   curl -OL https://gitpod.io/static/bin/gitpod-local-companion-darwin
+  chmod +x ./gitpod-local-companion-*
+
   # linux
   curl -OL https://gitpod.io/static/bin/gitpod-local-companion-linux
-  # windows
-  curl -OL https://gitpod.io/static/bin/gitpod-local-companion-windows
-
   chmod +x ./gitpod-local-companion-*
+
+  # windows
+  curl -OL https://gitpod.io/static/bin/gitpod-local-companion-windows.exe
 ```
 
 ## Running


### PR DESCRIPTION
Resolves https://community.gitpod.io/t/gitpod-windows-download-link-returns-a-404/3932

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/649"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

