### PR TITLE
fixes #665 - add postcss to style section declaration

### DIFF
--- a/src/components/banners/base.svelte
+++ b/src/components/banners/base.svelte
@@ -17,7 +17,7 @@
   });
 </script>
 
-<style>
+<style type="text/postcss">
   .top {
     @apply top-0;
   }

--- a/src/components/base/h1.svelte
+++ b/src/components/base/h1.svelte
@@ -1,4 +1,4 @@
-<style>
+<style type="text/postcss">
   h1 {
     font-style: normal;
     font-weight: bold;

--- a/src/components/docs/edit-in-gitpod.svelte
+++ b/src/components/docs/edit-in-gitpod.svelte
@@ -9,7 +9,7 @@
   const href = `${BASE_PATH}${currentPage}.md`;
 </script>
 
-<style>
+<style type="text/postcss">
   a::after {
     display: none !important;
   }

--- a/src/components/docs/feedback-widget.svelte
+++ b/src/components/docs/feedback-widget.svelte
@@ -30,7 +30,7 @@
   };
 </script>
 
-<style>
+<style type="text/postcss">
   .selected {
     @apply grayscale-0 scale-150;
   }

--- a/src/components/docs/menu-section.svelte
+++ b/src/components/docs/menu-section.svelte
@@ -13,8 +13,8 @@
     : /\/docs\/$/.test(menuItem.path);
 </script>
 
-<style lang="scss">
-  // override _forms.scss
+<style type="text/postcss">
+  /* override _forms.scss */
   .menu-item {
     margin-bottom: 0;
   }

--- a/src/routes/changelog/index.svelte
+++ b/src/routes/changelog/index.svelte
@@ -13,7 +13,7 @@
   export let changelogEntries: Changelog[];
 </script>
 
-<style>
+<style type="text/postcss">
   .content-docs :global(a) {
     @apply font-normal;
   }

--- a/src/routes/docs/$layout.svelte
+++ b/src/routes/docs/$layout.svelte
@@ -6,7 +6,7 @@
   import { MENU } from "./menu";
 </script>
 
-<style>
+<style type="text/postcss">
   .docs-layout {
     @apply pb-10;
 


### PR DESCRIPTION
Added `<style type="text/postcss">` to the style section declaration fixes `npm run validate` errors

before applying PR

```
====================================
svelte-check found 47 errors, 11 warnings and 70 hints
```

after PR

```
====================================
svelte-check found 28 errors, 10 warnings and 70 hints
```

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/666"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

