### PR TITLE
fixes #668 - use MenuEntry type for menu items

### DIFF
--- a/src/components/docs/menu-section.svelte
+++ b/src/components/docs/menu-section.svelte
@@ -1,8 +1,9 @@
-<script>
+<script lang="ts">
   import docsCurrentSectionStore from "../../stores/docs-current-section";
   import MenuLink from "./menu-link.svelte";
 
-  export let menuItem;
+  import type { MenuEntry } from "../../types/menu-entry.type";
+  export let menuItem: MenuEntry;
 
   $: isActiveSection = $docsCurrentSectionStore
     ? menuItem.path.indexOf(
@@ -13,8 +14,8 @@
     : /\/docs\/$/.test(menuItem.path);
 </script>
 
-<style lang="scss">
-  // override _forms.scss
+<style type="text/postcss">
+  /* override _forms.scss */
   .menu-item {
     margin-bottom: 0;
   }

--- a/src/components/docs/menu.svelte
+++ b/src/components/docs/menu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import MenuSection from "./menu-section.svelte";
-  export let MENU;
+  import type { MenuEntry } from "../../types/menu-entry.type";
+  export let MENU: MenuEntry[];
 </script>
 
 <ul class="space-y-8">

--- a/src/components/docs/mobile-menu/menu-item.svelte
+++ b/src/components/docs/mobile-menu/menu-item.svelte
@@ -4,7 +4,7 @@
 
   export let href: string;
   export let onClick;
-  export let showIcon: boolean;
+  export let showIcon: boolean = false;
 </script>
 
 <style lang="scss">

--- a/src/components/docs/mobile-menu/sub-menu.svelte
+++ b/src/components/docs/mobile-menu/sub-menu.svelte
@@ -6,7 +6,8 @@
   import topicsState from "../states/topics-state";
   import subMenuState from "../states/sub-menu-state";
 
-  export let currentSection: any = {};
+  import type { MenuEntry } from "../../../types/menu-entry.type";
+  export let currentSection: MenuEntry = null;
 </script>
 
 <style lang="scss">
@@ -75,7 +76,7 @@
   All topics
 </button>
 
-{#if currentSection.subMenu}
+{#if currentSection?.subMenu}
   <div class="sub-menu-container bg-white">
     <button
       class="toggle-button w-full"
@@ -84,7 +85,7 @@
       aria-expanded={$subMenuState}
       on:click={() => ($subMenuState = !$subMenuState)}
     >
-      <div class="toggle-button__label">{currentSection.title}</div>
+      <div class="toggle-button__label">{currentSection?.title}</div>
       <div class="toggle-button__icon">
         <img
           class={`toggle-button__icon-arrow ${$subMenuState ? "open" : ""}`}
@@ -97,13 +98,13 @@
     </button>
 
     <div
-      aria-label={currentSection.title}
+      aria-label={currentSection?.title}
       role="navigation"
       class={`px-4 ${$subMenuState ? "block" : "hidden"}`}
       id="sub-menu"
     >
       <ul>
-        {#each currentSection.subMenu as sub}
+        {#each currentSection?.subMenu as sub}
           <MenuItem href={sub.path} onClick={() => ($subMenuState = false)}>
             {sub.title}
           </MenuItem>

--- a/src/components/docs/mobile-menu/topics.svelte
+++ b/src/components/docs/mobile-menu/topics.svelte
@@ -5,7 +5,8 @@
   // States
   import topicsState from "../states/topics-state";
 
-  export let MENU;
+  import type { MenuEntry } from "../../../types/menu-entry.type";
+  export let MENU: MenuEntry[];
 </script>
 
 <div role="navigation" aria-label="All topics">

--- a/src/routes/docs/menu.ts
+++ b/src/routes/docs/menu.ts
@@ -1,9 +1,4 @@
-// This file is used to define entries in the side menu
-interface MenuEntry {
-  title: string;
-  path: string;
-  subMenu?: MenuEntry[];
-}
+import type { MenuEntry } from "../../types/menu-entry.type";
 
 function M(title: string, path: string, subMenu?: MenuEntry[]): MenuEntry {
   return {

--- a/src/types/menu-entry.type.ts
+++ b/src/types/menu-entry.type.ts
@@ -1,0 +1,5 @@
+export type MenuEntry = {
+  title: string;
+  path: string;
+  subMenu?: MenuEntry[];
+};


### PR DESCRIPTION
using MenuEntry type for menu items

`npm run validate` before PR

```
====================================
svelte-check found 47 errors, 11 warnings and 70 hints
```

`npm run validate` after PR

```
====================================
svelte-check found 39 errors, 11 warnings and 68 hints
```

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/669"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

