### PR TITLE
Add translations to the professional open source plan eligibility criteria

### DIFF
--- a/src/routes/docs/professional-open-source.md
+++ b/src/routes/docs/professional-open-source.md
@@ -21,7 +21,7 @@ No more hour restrictions, you'll be able to use Gitpod for any number of hours,
 
 You should meet **at least one** of the following requirements:
 
-1. You are a maintainer, or core contributor, of a well-established open-source project
+1. You are a maintainer, core contributor, or translator of a well-established open-source project
 2. A significant part of your income is from open source work (e.g. via Liberapay, Open Collective, GitHub Sponsors, Patreon, etc)
 3. You regularly contribute to open source in other ways (e.g. producing regular content like blog posts, videos, live streams, translations, or organizing meet-ups, conferences, hackathons, etc)
 

--- a/src/routes/docs/professional-open-source.md
+++ b/src/routes/docs/professional-open-source.md
@@ -23,7 +23,7 @@ You should meet **at least one** of the following requirements:
 
 1. You are a maintainer, or core contributor, of a well-established open-source project
 2. A significant part of your income is from open source work (e.g. via Liberapay, Open Collective, GitHub Sponsors, Patreon, etc)
-3. You regularly contribute to open source in other ways (e.g. producing regular content like blog posts, videos, live streams, or organizing meet-ups, conferences, hackathons, etc)
+3. You regularly contribute to open source in other ways (e.g. producing regular content like blog posts, videos, live streams, translations, or organizing meet-ups, conferences, hackathons, etc)
 
 Does one of the above apply to your work? If so, please [get in touch](/contact) and provide links to your projects. We'd love to see what you're working on.
 


### PR DESCRIPTION
This will add _translations_ in the eligibility criteria for the professional open source plan. Feel free to close if needed. 📕 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/671"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

