### PR TITLE
fixes #677 - updated svelte-check to latest minor version - 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6680,6 +6680,12 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -6911,9 +6917,9 @@
       "dev": true
     },
     "svelte-check": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-1.2.5.tgz",
-      "integrity": "sha512-1hqlH/J86lpuXk6+SSeZRfCfxXvCpqYGfgPb2sD0YW+tueknbJGR9oaGaLzytU0dgja4ShG+zQzHEsjKb0tFeA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-1.6.0.tgz",
+      "integrity": "sha512-nQTlbFJWhwoeLY5rkhgbjzGQSwk5F1pRdEXait0EFaQSrE/iJF+PIjrQlk0BjL/ogk9HaR9ZI0DQSYrl7jl3IQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -6921,6 +6927,7 @@
         "glob": "^7.1.6",
         "import-fresh": "^3.2.1",
         "minimist": "^1.2.5",
+        "sade": "^1.7.4",
         "source-map": "^0.7.3",
         "svelte-preprocess": "^4.0.0",
         "typescript": "*"
@@ -6936,9 +6943,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -6964,12 +6971,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rollup-plugin-terser": "^7.0.0",
     "sass": "^1.32.8",
     "svelte": "^3.37.0",
-    "svelte-check": "^1.0.46",
+    "svelte-check": "^1.6.0",
     "svelte-preprocess": "^4.6.9",
     "tailwindcss": "^2.1.2",
     "tslib": "^2.0.1",


### PR DESCRIPTION
refs #652
fixes #677 

updating svelte-check from 1.2.5 to latest minor version (1.6.0) resolved the problem of the anchor with `sveltekit:prefetch` being reported as errors

previous error count:

```
svelte-check found 29 errors, 11 warnings and 71 hints
```

after

```
svelte-check found 23 errors, 11 warnings and 71 hints
```

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/678"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

