### PR TITLE
fixes #679 - add types to google-analytics.svelte

### DIFF
--- a/src/components/docs/search.svelte
+++ b/src/components/docs/search.svelte
@@ -1,3 +1,17 @@
+<script lang="ts" context="module">
+  declare global {
+    type docsearchParamType = {
+      apiKey: string;
+      indexName: string;
+      inputSelector: string;
+      debug: boolean;
+    };
+    interface Window {
+      docsearch: (param: docsearchParamType) => void;
+    }
+  }
+</script>
+
 <script lang="ts">
   import { onMount } from "svelte";
   import topicsState from "./states/topics-state";

--- a/src/components/google-analytics.svelte
+++ b/src/components/google-analytics.svelte
@@ -1,4 +1,16 @@
-<script>
+<script lang="ts" context="module">
+  declare global {
+    interface Window {
+      dataLayer: any[];
+      gtag: (...n: any) => void;
+    }
+    interface Navigator {
+      msDoNotTrack: string;
+    }
+  }
+</script>
+
+<script lang="ts">
   // This component is taken from https://angelblanco.dev/articles/add-gtag-analytics-to-sapper/ and adjusted to meet Gitpod requirements.
   import { page } from "$app/stores";
   import { onMount } from "svelte";
@@ -64,8 +76,8 @@
     window.gtag = function () {
       window.dataLayer.push(arguments);
     };
-    gtag("js", new Date());
-    gtag("config", trackingId, gtagOptions);
+    window.gtag("js", new Date());
+    window.gtag("config", trackingId, gtagOptions);
 
     try {
       await addGoogleAnalyticsScript();
@@ -87,7 +99,7 @@
     const page_path = $page.path;
 
     if (isProd() && !isDoNotTrack() && mounted && window.gtag) {
-      gtag("config", trackingId, { ...gtagOptions, page_path });
+      window.gtag("config", trackingId, { ...gtagOptions, page_path });
     }
   }
 </script>


### PR DESCRIPTION
running `npm run validate` before PR:

```
svelte-check found 29 errors, 11 warnings and 71 hints
```

after

```
svelte-check found 20 errors, 11 warnings and 71 hints
```

added the following type declaration

```ts
<script lang="ts" context="module">
  declare global {
    interface Window {
      dataLayer: any[];
      gtag: (...n: any) => void;
    }
    interface Navigator {
      msDoNotTrack: string;
    }
  }
</script>
```

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/680"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

