### PR TITLE
hide overflow-x on the body to aviod vertical scaling off the screen.

### DIFF
--- a/src/assets/scss/_reset.scss
+++ b/src/assets/scss/_reset.scss
@@ -12,6 +12,7 @@
 html {
   box-sizing: border-box;
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Fixes #676 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/682"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

