### PR TITLE
Add copyright year date at the footer #632

### DIFF
--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -89,7 +89,7 @@
               width="24"
             />
           </div></a
-        ><span>Copyright &copy; Gitpod</span>
+        ><span>Copyright &copy; {new Date().getFullYear()} Gitpod</span>
       </div>
       <div class="footer__social">
         {#each socialLinks as link}


### PR DESCRIPTION
Fixes #632  

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/123452864-46b7fa00-d5f8-11eb-90ee-7d055fd7875e.png)


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/684"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

