### PR TITLE
Update docs for port visibility

### DIFF
--- a/src/routes/docs/config-ports.md
+++ b/src/routes/docs/config-ports.md
@@ -58,10 +58,10 @@ Any changes to the `.gitpod.yml` will have effect immediately.
 
 ## Configure port visibility
 
-By default, all ports are in public visibiltiy state.
+By default, all ports are in private visibility state.
 
 To change this behavior you can provide the property `visibility`.
 It has two possible values:
 
-- `public` (default) - Allows everyone with the port URL to access the port.
-- `private` - Only allow users with workspace access to access the port.
+- `private` (default) - Only allow users with workspace access to access the port.
+- `public` - Allows everyone with the port URL to access the port.

--- a/src/routes/docs/references/gitpod-yml.md
+++ b/src/routes/docs/references/gitpod-yml.md
@@ -257,9 +257,9 @@ Define whether to expose the port publicly or keep it private.
 
 A public port allows you to share a URL for a given port with team members, for example if you want to get their feedback on a new feature you develop.
 
-| Type     | Default  | Values                     |
-| -------- | -------- | -------------------------- |
-| `string` | `public` | `private`,<br><br>`public` |
+| Type     | Default   | Values                     |
+| -------- | --------- | -------------------------- |
+| `string` | `private` | `private`,<br><br>`public` |
 
 ## `tasks`
 


### PR DESCRIPTION
Following the updates in https://github.com/gitpod-io/gitpod/pull/4614 and https://github.com/gitpod-io/gitpod/pull/4548, this will update docs for port visibility in the following two sections:

1. [Exposing Ports](https://www.gitpod.io/docs/config-ports)
2. [`.gitpod.yml` Reference](https://www.gitpod.io/docs/references/gitpod-yml)

Cc @corneliusludmann 