### PR TITLE
Remove link on self-hosted page

### DIFF
--- a/src/routes/docs/self-hosted/0.7.0/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/0.7.0/install/install-on-kubernetes.md
@@ -52,7 +52,7 @@ To install Gitpod in your Kubernetes cluster, follow these steps:
 
 1. Run `kubectl get pods` and verify that all pods are in state `RUNNING`. If some are not, please see the [Troubleshooting Guide](./troubleshooting).
 
-1. Go to [https://\<your-domain.com\>](https://<your-domain.com>) and follow the steps to complete the installation.
+1. Go to `https://<your-domain.com>` and follow the steps to complete the installation.
 
 ## Upgrade
 

--- a/src/routes/docs/self-hosted/0.8.0/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/0.8.0/install/install-on-kubernetes.md
@@ -52,7 +52,7 @@ To install Gitpod in your Kubernetes cluster, follow these steps:
 
 1. Run `kubectl get pods` and verify that all pods are in state `RUNNING`. If some are not, please see the [Troubleshooting Guide](./troubleshooting).
 
-1. Go to [https://\<your-domain.com\>](https://<your-domain.com>) and follow the steps to complete the installation.
+1. Go to `https://<your-domain.com>` and follow the steps to complete the installation.
 
 ## Upgrade
 

--- a/src/routes/docs/self-hosted/latest/install/install-on-kubernetes.md
+++ b/src/routes/docs/self-hosted/latest/install/install-on-kubernetes.md
@@ -63,7 +63,7 @@ To install Gitpod in your Kubernetes cluster, follow these steps:
 
 1. Run `kubectl get pods` and verify that all pods are in state `RUNNING`. If some are not, please see the [Troubleshooting Guide](./troubleshooting).
 
-1. Go to [https://\<your-domain.com\>](https://<your-domain.com>) and follow the steps to complete the installation.
+1. Go to `https://<your-domain.com>` and follow the steps to complete the installation.
 
 ## Upgrade
 


### PR DESCRIPTION
Related to this issue: https://github.com/gitpod-io/website/issues/708.

I've suggested removing that link all together. It was confusing having that there to be with (in my opinion) and makes more sense highlighted like a code block. 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/723"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

