### PR TITLE
Add Languages & Frameworks to nav.

### DIFF
--- a/src/routes/docs/languages-and-frameworks.md
+++ b/src/routes/docs/languages-and-frameworks.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Languages & Frameworks
 ---
 

--- a/src/routes/docs/languages/bash.md
+++ b/src/routes/docs/languages/bash.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Bash in Gitpod
 ---
 

--- a/src/routes/docs/languages/cpp.md
+++ b/src/routes/docs/languages/cpp.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: C++ in Gitpod
 ---
 

--- a/src/routes/docs/languages/dart.md
+++ b/src/routes/docs/languages/dart.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Dart in Gitpod
 ---
 

--- a/src/routes/docs/languages/deno.md
+++ b/src/routes/docs/languages/deno.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Deno in Gitpod
 ---
 

--- a/src/routes/docs/languages/dotnet.md
+++ b/src/routes/docs/languages/dotnet.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: .NET in Gitpod
 ---
 

--- a/src/routes/docs/languages/go.md
+++ b/src/routes/docs/languages/go.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Go in Gitpod
 ---
 

--- a/src/routes/docs/languages/html.md
+++ b/src/routes/docs/languages/html.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: HTML & CSS in Gitpod
 ---
 

--- a/src/routes/docs/languages/java.md
+++ b/src/routes/docs/languages/java.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Java in Gitpod
 ---
 

--- a/src/routes/docs/languages/javascript.md
+++ b/src/routes/docs/languages/javascript.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: JavaScript in Gitpod
 ---
 

--- a/src/routes/docs/languages/julia.md
+++ b/src/routes/docs/languages/julia.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Julia in Gitpod
 ---
 

--- a/src/routes/docs/languages/kotlin.md
+++ b/src/routes/docs/languages/kotlin.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Kotlin in Gitpod
 ---
 

--- a/src/routes/docs/languages/latex.md
+++ b/src/routes/docs/languages/latex.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: LaTeX in Gitpod
 ---
 

--- a/src/routes/docs/languages/php.md
+++ b/src/routes/docs/languages/php.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: PHP in Gitpod
 ---
 

--- a/src/routes/docs/languages/python.md
+++ b/src/routes/docs/languages/python.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Python in Gitpod
 ---
 

--- a/src/routes/docs/languages/r.md
+++ b/src/routes/docs/languages/r.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: R in Gitpod
 ---
 

--- a/src/routes/docs/languages/ruby.md
+++ b/src/routes/docs/languages/ruby.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Ruby in Gitpod
 ---
 

--- a/src/routes/docs/languages/rust.md
+++ b/src/routes/docs/languages/rust.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Rust in Gitpod
 ---
 

--- a/src/routes/docs/languages/scala.md
+++ b/src/routes/docs/languages/scala.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Scala in Gitpod
 ---
 

--- a/src/routes/docs/languages/svelte.md
+++ b/src/routes/docs/languages/svelte.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Svelte in Gitpod
 ---
 

--- a/src/routes/docs/languages/vue.md
+++ b/src/routes/docs/languages/vue.md
@@ -1,5 +1,5 @@
 ---
-section: languages-and-frameworks
+section: references
 title: Vue.js in Gitpod
 ---
 

--- a/src/routes/docs/menu.ts
+++ b/src/routes/docs/menu.ts
@@ -78,6 +78,7 @@ export const MENU: MenuEntry[] = [
     // M("Custom Docker image", "references/gitpod-dockerfile"),
     // M("Architecture", "references/architecture"),
     // M("Troubleshooting", "references/troubleshooting"),
+    M("Languages & Framework", "languages-and-frameworks"),
     M("Changelog", "references/changelog"),
     M("Roadmap", "references/roadmap"),
   ]),

--- a/src/routes/docs/references/index.md
+++ b/src/routes/docs/references/index.md
@@ -13,5 +13,6 @@ Below are links to Gitpod reference material you may find helpful:
 
 - [`.gitpod.yml`](/docs/references/gitpod-yml)
 - [Command Line Interface](/docs/command-line-interface)
+- [Languages & Framework](languages-and-frameworks)
 - [Changelog](/docs/references/changelog)
 - [Roadmap](/docs/references/roadmap)


### PR DESCRIPTION
Quick fix without a corresponding issue to add Languages & Frameworks to the docs nav under References.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/735"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

