### PR TITLE
[analytics] Add Segment tracking events

### DIFF
--- a/src/components/blog/blog-content-layout.svelte
+++ b/src/components/blog/blog-content-layout.svelte
@@ -52,6 +52,7 @@
       )}`,
       alt: "Twitter",
       icon: "/svg/brands/twitter.svg",
+      trackingName: "twitter",
     },
     {
       href: `http://www.reddit.com/submit?url=${encodeURIComponent(
@@ -59,6 +60,7 @@
       )}`,
       alt: "Reddit",
       icon: "/svg/brands/reddit.svg",
+      trackingName: "reddit",
     },
   ];
 </script>
@@ -103,7 +105,13 @@
     <ul>
       {#each socialLinks as link}
         <li>
-          <a href={link.href}>
+          <a
+            href={link.href}
+            on:click={() =>
+              window.analytics.track("content_share_clicked", {
+                medium: link.trackingName,
+              })}
+          >
             <img src={link.icon} alt={link.alt} height="24" width="24" />
           </a>
         </li>

--- a/src/components/careers/modal.svelte
+++ b/src/components/careers/modal.svelte
@@ -37,7 +37,11 @@
     <a
       class="btn-conversion"
       href="mailto:career@gitpod.io?subject=Application as {career.title}"
-      >Apply now</a
+      on:click={() =>
+        window.analytics.track("hiring_interaction", {
+          subtype: "apply_clicked",
+          name: career.title,
+        })}>Apply now</a
     >
   </p>
 </Modal>

--- a/src/components/contact/card.svelte
+++ b/src/components/contact/card.svelte
@@ -25,7 +25,11 @@
   />
   <h2 class="h3">{contactCard.title}</h2>
   <p>{contactCard.description}</p>
-  <a href={contactCard.btnHref} class="btn btn-conversion m-8"
-    >{contactCard.btnText}</a
+  <a
+    href={contactCard.btnHref}
+    on:click={() => {
+      if (contactCard.tracking) contactCard.tracking();
+    }}
+    class="btn btn-conversion m-8">{contactCard.btnText}</a
   >
 </div>

--- a/src/components/docs/edit-in-gitpod.svelte
+++ b/src/components/docs/edit-in-gitpod.svelte
@@ -25,7 +25,13 @@
 </style>
 
 <div class="flex justify-end mb-micro">
-  <a {href} class="btn-otherbrand" target="_blank">
+  <a
+    {href}
+    target="_blank"
+    on:click={() =>
+      window.analytics.track("gitpod_editor_clicked", { context: "docs" })}
+    class="btn-otherbrand"
+  >
     <span class="logo">
       <LogoTextless />
     </span> <span class="ml-macro">Edit in Gitpod</span>

--- a/src/components/docs/feedback-widget.svelte
+++ b/src/components/docs/feedback-widget.svelte
@@ -9,6 +9,12 @@
 
   const submitFeedback = async () => {
     isSubmittedOnce = true;
+
+    window.analytics.track("feedback_submitted", {
+      score: selectedEmotion,
+      feedback: note,
+    });
+
     const response = await fetch("/.netlify/functions/feedback", {
       method: "post",
       body: JSON.stringify({

--- a/src/components/faqs/faq.svelte
+++ b/src/components/faqs/faq.svelte
@@ -4,13 +4,20 @@
   import { hyphenate } from "../../utils/helper";
 
   export let title;
+  export let trackingContext;
 
   const activeFaq = getContext(faqsKey);
   const fragment = hyphenate(title);
 
   const setActive = ({ target }) => {
     const open = target.open;
-    if (open) $activeFaq = title;
+    if (open) {
+      $activeFaq = title;
+      window.analytics.track("pricing_faq_opened", {
+        context: trackingContext,
+        name: title,
+      });
+    }
     // closing the faq that was active, no faq will remain open
     if (isActive && !open) $activeFaq = null;
   };

--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -4,16 +4,19 @@
       href: "https://twitter.com/gitpod",
       alt: "Twitter",
       icon: "/svg/brands/twitter.svg",
+      trackingName: "twitter",
     },
     {
       href: "https://github.com/gitpod-io",
       alt: "GitHub",
       icon: "/svg/brands/github.svg",
+      trackingName: "github",
     },
     {
       href: "https://community.gitpod.io/",
       alt: "Discourse",
       icon: "/svg/brands/discourse.svg",
+      trackingName: "discourse",
     },
   ];
 </script>
@@ -89,7 +92,16 @@
           </a>
         </li>
         <li>
-          <a href="https://www.gitpodstatus.com/" target="_blank">Status</a>
+          <a
+            href="https://www.gitpodstatus.com/"
+            target="_blank"
+            on:click={() =>
+              window.analytics.track("external_resource_clicked", {
+                context: "footer",
+                name: "status",
+                url: "https://www.gitpodstatus.com/",
+              })}>Status</a
+          >
         </li>
       </ul>
       <ul>
@@ -102,13 +114,27 @@
           <a
             href="https://github.com/gitpod-io/gitpod/issues/new?template=bug_report.md"
             target="_blank"
-            rel="noopener">Report a bug</a
+            rel="noopener"
+            on:click={() =>
+              window.analytics.track("external_resource_clicked", {
+                context: "footer",
+                name: "bug-report",
+                url:
+                  "https://github.com/gitpod-io/gitpod/issues/new?template=bug_report.md",
+              })}>Report a bug</a
           >
         </li>
         <li>
-          <a href="https://community.gitpod.io" target="_blank" rel="noopener"
-            >Community
-          </a>
+          <a
+            href="https://community.gitpod.io"
+            target="_blank"
+            rel="noopener"
+            on:click={() =>
+              window.analytics.track("social_opened", {
+                context: "footer",
+                platform: "discourse",
+              })}>Community</a
+          >
         </li>
       </ul>
       <ul>
@@ -151,7 +177,15 @@
       </div>
       <div class="flex">
         {#each socialLinks as link}
-          <a href={link.href} class="footer__social-link">
+          <a
+            href={link.href}
+            on:click={() =>
+              window.analytics.track("social_opened", {
+                context: "footer-logo",
+                platform: link.trackingName,
+              })}
+            class="footer__social-link"
+          >
             <img src={link.icon} alt={link.alt} height="24" width="24" />
           </a>
         {/each}

--- a/src/components/index/brand.svelte
+++ b/src/components/index/brand.svelte
@@ -56,7 +56,17 @@
   }
 </style>
 
-<a {href} target="_blank" rel="noopener" class="brand">
+<a
+  {href}
+  target="_blank"
+  on:click={() =>
+    window.analytics.track("socialproof_clicked", {
+      type: "logo",
+      url: href,
+    })}
+  rel="noopener"
+  class="brand"
+>
   <img
     src={`/${logo}`}
     {alt}

--- a/src/components/index/get-started/link-git-repository.svelte
+++ b/src/components/index/get-started/link-git-repository.svelte
@@ -70,7 +70,14 @@
   Select a Git provider to start with an existing project from any Git context.
 </p>
 <div class="buttons">
-  <a href="https://gitpod.io/login" class="btn btn--gitlab">
+  <a
+    href="https://gitpod.io/login"
+    on:click={() =>
+      window.analytics.track("dashboard_clicked", {
+        context: "continue_gitlab",
+      })}
+    class="btn btn--gitlab"
+  >
     <svg viewBox="0 0 30 28" fill="none" xmlns="http://www.w3.org/2000/svg">
       <title>Bitbucket</title>
       <path
@@ -102,7 +109,14 @@
     >
     Continue with GitLab
   </a>
-  <a href="https://gitpod.io/login" class="btn btn--github">
+  <a
+    href="https://gitpod.io/login"
+    on:click={() =>
+      window.analytics.track("dashboard_clicked", {
+        context: "continue_github",
+      })}
+    class="btn btn--github"
+  >
     <svg viewBox="0 0 29 30" fill="none" xmlns="http://www.w3.org/2000/svg">
       <title>GitHub Octocat</title>
       <path
@@ -114,7 +128,14 @@
     </svg>
     Continue with GitHub
   </a>
-  <a href="https://gitpod.io/login" class="btn btn--bitbucket">
+  <a
+    href="https://gitpod.io/login"
+    on:click={() =>
+      window.analytics.track("dashboard_clicked", {
+        context: "continue_bitbucket",
+      })}
+    class="btn btn--bitbucket"
+  >
     <svg viewBox="0 0 27 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <title>Bitbucket</title>
       <path

--- a/src/components/index/get-started/project.svelte
+++ b/src/components/index/get-started/project.svelte
@@ -1,6 +1,6 @@
 <script>
   export let project;
-  const { logo, alt, title, githubUrl } = project;
+  const { logo, alt, title, githubUrl, trackingName } = project;
 </script>
 
 <style lang="scss">
@@ -70,6 +70,11 @@
 <a
   href={`https://gitpod.io#${githubUrl}`}
   target="_blank"
+  on:click={() =>
+    window.analytics.track("example_workspace_clicked", {
+      name: trackingName,
+      repo_url: githubUrl,
+    })}
   class="project group"
 >
   <div class="project__left">

--- a/src/components/index/hero.svelte
+++ b/src/components/index/hero.svelte
@@ -178,6 +178,11 @@
             bind:this={githubStarsEl}
             class="github-button"
             href="https://github.com/gitpod-io/gitpod"
+            on:click={() =>
+              window.analytics.track("social_opened", {
+                platform: "github",
+                context: "hero",
+              })}
             data-icon="octicon-star"
             data-size="large"
             data-show-count="true"

--- a/src/components/index/section-screenshot.svelte
+++ b/src/components/index/section-screenshot.svelte
@@ -3,12 +3,14 @@
 
   const buttons = [
     {
+      name: "chrome-extension",
       icon: "svg/browsers/chrome.svg",
       text: "Chrome Extension",
       href:
         "https://chrome.google.com/webstore/detail/gitpod-dev-environments-i/dodmmooeoklaejobgleioelladacbeki",
     },
     {
+      name: "firefox-extension",
       icon: "svg/browsers/firefox.svg",
       text: "Firefox Extension",
       href: "https://addons.mozilla.org/firefox/addon/gitpod/",
@@ -67,10 +69,15 @@
         networks.
       </p>
       <div class="buttons-wrapper">
-        {#each buttons as { href, icon, text }}
+        {#each buttons as { name, href, icon, text }}
           <a
             {href}
             target="_blank"
+            on:click={() =>
+              window.analytics.track("feature_clicked", {
+                type: name,
+                url: href,
+              })}
             rel="noopener"
             class="btn-otherbrand text-medium"
           >

--- a/src/components/index/testimonial.svelte
+++ b/src/components/index/testimonial.svelte
@@ -3,6 +3,8 @@
   export let testimonial: Testimonial;
 
   const { name, avatar, role, org, text, twitterHandle, tweetId } = testimonial;
+
+  export let position: Number;
 </script>
 
 <style lang="scss">
@@ -32,6 +34,12 @@
 <a
   href={`https://twitter.com/${twitterHandle}/status/${tweetId}`}
   target="_blank"
+  on:click={() =>
+    window.analytics.track("socialproof_clicked", {
+      type: "tweet",
+      url: `https://twitter.com/${twitterHandle}/status/${tweetId}`,
+      position: position,
+    })}
   class="my-2 text-small"
 >
   <div

--- a/src/components/index/testimonials.svelte
+++ b/src/components/index/testimonials.svelte
@@ -40,8 +40,8 @@
   <div class="row">
     <h2 class="h1">Used by 400,000+ developers.</h2>
     <Carousel>
-      {#each testimonials as testimonial}
-        <Testimonial {testimonial} />
+      {#each testimonials as testimonial, position}
+        <Testimonial {testimonial} {position} />
       {/each}
     </Carousel>
     <Brands />

--- a/src/components/main-nav/login-button.svelte
+++ b/src/components/main-nav/login-button.svelte
@@ -1,5 +1,9 @@
 <a
   href="https://gitpod.io/login/"
+  on:click={() =>
+    window.analytics.track("dashboard_clicked", {
+      context: "header_button",
+    })}
   class="flex items-center justify-center h-8 w-20 rounded-xl bg-black font-bold text-off-white text-sm focus:text-off-white focus:bg-black-hover hover:text-off-white hover:bg-black-hover"
 >
   Login

--- a/src/components/media-kit/founders.svelte
+++ b/src/components/media-kit/founders.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import Section from "../section.svelte";
+
+  const imgSrc = "/images/media-kit/founders.jpg";
 </script>
 
 <Section className="text-center">
@@ -7,13 +9,17 @@
   <div
     class="shadow-normal rounded-4xl bg-white p-small sm:p-x-large mb-x-large"
   >
-    <img
-      src="/images/media-kit/founders.jpg"
-      alt="Gitpod founders group"
-      class="rounded-4xl mx-auto"
-    />
+    <img src="imgSrc" alt="Gitpod founders group" class="rounded-4xl mx-auto" />
     <p class="py-xx-small">Download founder group picture</p>
-    <a href="/images/media-kit/founders.jpg" download class="btn-cta">PNG</a>
+    <a
+      href="imgSrc"
+      on:click={() =>
+        window.analytics.track("media_downloaded", {
+          name: imgSrc,
+        })}
+      download
+      class="btn-cta">PNG</a
+    >
   </div>
   <p class="text-large">
     Please <a href="/contact">contact us</a> for any intended use not covered by

--- a/src/components/media-kit/image-box.svelte
+++ b/src/components/media-kit/image-box.svelte
@@ -9,5 +9,13 @@
 >
   <img {src} {alt} class={`${imgClass} rounded m-auto w-full`} />
   <p class="mt-small mb-micro max-w-sm mx-auto">Download {text}</p>
-  <a href={src} class="btn-cta" download>{btnText}</a>
+  <a
+    href={src}
+    on:click={() =>
+      window.analytics.track("media_downloaded", {
+        name: src,
+      })}
+    class="btn-cta"
+    download>{btnText}</a
+  >
 </div>

--- a/src/components/media-kit/logo-box.svelte
+++ b/src/components/media-kit/logo-box.svelte
@@ -33,7 +33,23 @@
   <img src={svgSrc} {alt} class="mx-auto" />
   <p class="mt-medium mb-micro">Download {text}</p>
   <div class="buttons-wrapper">
-    <a href={svgSrc} download class="btn-cta svg-button">SVG</a>
-    <a href={`/images/media-kit/${srcPNG}`} download class="btn-cta">PNG</a>
+    <a
+      href={svgSrc}
+      on:click={() =>
+        window.analytics.track("media_downloaded", {
+          name: svgSrc,
+        })}
+      download
+      class="btn-cta svg-button">SVG</a
+    >
+    <a
+      href={`/images/media-kit/${srcPNG}`}
+      on:click={() =>
+        window.analytics.track("media_downloaded", {
+          name: srcPNG,
+        })}
+      download
+      class="btn-cta">PNG</a
+    >
   </div>
 </div>

--- a/src/components/pricing/faqs.svelte
+++ b/src/components/pricing/faqs.svelte
@@ -1,8 +1,10 @@
-<script>
+<script lang="ts">
   import { isEurope } from "../../utils/helper";
   import Section from "../section.svelte";
   import Faqs from "../faqs/faqs.svelte";
   import Faq from "../faqs/faq.svelte";
+
+  export let trackingContext: String;
 </script>
 
 <style lang="scss">
@@ -23,7 +25,7 @@
 <Section>
   <Faqs>
     <h2 class="h1">FAQs</h2>
-    <Faq title="Can I always use Gitpod for free?">
+    <Faq title="Can I always use Gitpod for free?" {trackingContext}>
       <p>
         Yes! Gitpod is always for free for public repositories for up to 50h per
         month. If you need more hours or would like to unlock more features, you
@@ -35,6 +37,7 @@
     </Faq>
     <Faq
       title="Do you offer discounts for students and educational institutions?"
+      {trackingContext}
     >
       <p>
         Yes, qualified educational institutions may receive a special discount.
@@ -45,7 +48,7 @@
         <a href="#plans">Gitpod for Students</a> for more information.
       </p>
     </Faq>
-    <Faq title="How can I pay?">
+    <Faq title="How can I pay?" {trackingContext}>
       <p>All our plans can only be paid via credit card.</p>
       <div class="images">
         <img
@@ -57,7 +60,7 @@
         <img src="/svg/brands/visa.svg" alt="Visa" width="72" height="40" />
       </div>
     </Faq>
-    <Faq title="Can I create a team account?">
+    <Faq title="Can I create a team account?" {trackingContext}>
       <p>
         Sure, if you would like to mange subscriptions for a whole team on a
         single invoice, you can create a{" "}
@@ -69,7 +72,7 @@
         <a href="/docs/teams">gitpod.io/docs/teams.</a>
       </p>
     </Faq>
-    <Faq title="Can I change my subscription at any time?">
+    <Faq title="Can I change my subscription at any time?" {trackingContext}>
       <p>
         Yes, you can upgrade or downgrade whenever you want on <a
           href="https://gitpod.io/subscription/">gitpod.io/subscription</a
@@ -82,14 +85,14 @@
         your next month’s invoice.
       </p>
     </Faq>
-    <Faq title="What if I decide to cancel?">
+    <Faq title="What if I decide to cancel?" {trackingContext}>
       <p>
         If you wish to stop using Gitpod, you may cancel your subscription at
         any time. Your cancellation will take into effect after that month’s
         billing cycle.
       </p>
     </Faq>
-    <Faq title="Still have more questions?">
+    <Faq title="Still have more questions?" {trackingContext}>
       <p>
         We are happy to answer them, please <a href="/contact">Get in Touch</a>.
       </p>

--- a/src/components/pricing/other-plans.svelte
+++ b/src/components/pricing/other-plans.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
   import Section from "../section.svelte";
 
-  export let otherPlans;
+  export let otherPlans: any[];
+  export let trackingContext: String;
 </script>
 
 <style lang="scss">
@@ -53,7 +54,16 @@
           {#each p.paragraphs as para}
             <p>{@html para}</p>
           {/each}
-          <a href={p.btnHref} class="btn-cta">{p.btnText}</a>
+          <a
+            href={p.btnHref}
+            on:click={() =>
+              window.analytics.track("pricing_plan_clicked", {
+                context: trackingContext,
+                plan: p.trackingName,
+                name: "cta",
+              })}
+            class="btn-cta">{p.btnText}</a
+          >
         </div>
       </div>
     {/each}

--- a/src/components/pricing/plans-and-pricing.svelte
+++ b/src/components/pricing/plans-and-pricing.svelte
@@ -1,7 +1,9 @@
-<script>
+<script lang="ts">
   import { pricingPlans } from "../../contents/pricing";
   import Section from "../section.svelte";
   import PricingBoxes from "./pricing-boxes.svelte";
+
+  export let trackingContext: String;
 </script>
 
 <style>
@@ -12,5 +14,5 @@
 
 <Section>
   <h1>Plans and pricing</h1>
-  <PricingBoxes {pricingPlans} />
+  <PricingBoxes {trackingContext} {pricingPlans} />
 </Section>

--- a/src/components/pricing/pricing-box.svelte
+++ b/src/components/pricing/pricing-box.svelte
@@ -12,7 +12,10 @@
     spiced,
     learnMoreHref,
     footnote,
+    trackingName,
   } = pricing;
+
+  export let trackingContext: String;
 </script>
 
 <style type="text/postcss">
@@ -85,7 +88,16 @@
     {/if}
   </div>
   {#if btnHref && btnText}
-    <a href={btnHref} class="btn-cta">{btnText}</a>
+    <a
+      href={btnHref}
+      on:click={() =>
+        window.analytics.track("pricing_plan_clicked", {
+          context: trackingContext,
+          plan: trackingName,
+          name: "cta",
+        })}
+      class="btn-cta">{btnText}</a
+    >
   {/if}
   {#if footnote}
     <div class="text-p-xsmall px-small text-gray-700">{footnote}</div>

--- a/src/components/pricing/pricing-boxes.svelte
+++ b/src/components/pricing/pricing-boxes.svelte
@@ -3,10 +3,11 @@
   import PricingBox from "./pricing-box.svelte";
 
   export let pricingPlans: Pricing[];
+  export let trackingContext: String;
 </script>
 
 <div class="pricingContainer">
   {#each pricingPlans as pricing}
-    <PricingBox {pricing} />
+    <PricingBox {trackingContext} {pricing} />
   {/each}
 </div>

--- a/src/components/self-hosted/faqs.svelte
+++ b/src/components/self-hosted/faqs.svelte
@@ -1,7 +1,9 @@
-<script>
+<script lang="ts">
   import Section from "../section.svelte";
   import Faqs from "../faqs/faqs.svelte";
   import Faq from "../faqs/faq.svelte";
+
+  export let trackingContext: String;
 </script>
 
 <style lang="scss">
@@ -13,7 +15,7 @@
 <Section>
   <Faqs>
     <h2 class="h1">FAQs</h2>
-    <Faq title="Can I create a team account?">
+    <Faq title="Can I create a team account?" {trackingContext}>
       <p>
         Of course! You can use Gitpod Self-Hosted on your own infrastructure for
         free for unlimited users. If you'd like to access additional features
@@ -25,12 +27,15 @@
         <a href="/contact">Get in touch</a> if you have any questions.
       </p>
     </Faq>
-    <Faq title="Can I add more users to my plan at any time?">
+    <Faq title="Can I add more users to my plan at any time?" {trackingContext}>
       <p>
         Yes, you can add as many users as you like to your plan at any time.
       </p>
     </Faq>
-    <Faq title="What is the difference between SaaS and Self-Hosted?">
+    <Faq
+      title="What is the difference between SaaS and Self-Hosted?"
+      {trackingContext}
+    >
       <p>
         If you choose <strong>Gitpod SaaS</strong>, we will manage and host
         Gitpod in the cloud for you. This means minimal setup efforts for you
@@ -46,7 +51,7 @@
         for teams who want to keep full data control or use Gitpod in private networks.
       </p>
     </Faq>
-    <Faq title="How can I install Self-Hosted?">
+    <Faq title="How can I install Self-Hosted?" {trackingContext}>
       <p>
         You can either install <strong>Gitpod Self-Hosted</strong> on
         <strong>Google Cloud Platform</strong> or on
@@ -56,7 +61,7 @@
         > for more information.
       </p>
     </Faq>
-    <Faq title="How can I pay?">
+    <Faq title="How can I pay?" {trackingContext}>
       <p>
         Currently, <strong>Gitpod Self-Hosted</strong> can only be purchased on
         request. Please request a license key
@@ -66,13 +71,16 @@
         invoice.
       </p>
     </Faq>
-    <Faq title="Do you offer discounts for educational institutions?">
+    <Faq
+      title="Do you offer discounts for educational institutions?"
+      {trackingContext}
+    >
       <p>
         Yes, qualified educational institutions may receive a special discount.
         Please <a href="/contact">Contact sales</a>.
       </p>
     </Faq>
-    <Faq title="Still have more questions?">
+    <Faq title="Still have more questions?" {trackingContext}>
       <p>
         We are happy to answer them, please <a href="/contact">Get in Touch</a>.
       </p>

--- a/src/components/self-hosted/plans-and-pricing.svelte
+++ b/src/components/self-hosted/plans-and-pricing.svelte
@@ -1,7 +1,9 @@
-<script>
+<script lang="ts">
   import { pricingPlans } from "../../contents/self-hosted";
   import Section from "../section.svelte";
   import PricingBoxes from "../pricing/pricing-boxes.svelte";
+
+  export let trackingContext: String;
 </script>
 
 <header class="tight">
@@ -12,5 +14,5 @@
   </p>
 </header>
 <div class="self-hosted-pricing">
-  <PricingBoxes {pricingPlans} />
+  <PricingBoxes {trackingContext} {pricingPlans} />
 </div>

--- a/src/components/youtube-embed.svelte
+++ b/src/components/youtube-embed.svelte
@@ -1,6 +1,57 @@
+<script context="module" lang="ts">
+  declare global {
+    interface Window {
+      onYouTubeIframeAPIReady: any;
+    }
+    var YT: any;
+  }
+</script>
+
 <script lang="ts">
+  import { onMount } from "svelte";
+
   export let embedId: string;
   export let title: string;
+
+  const randomId = "yt-player-" + Math.random().toString(36).slice(2, 5);
+  let videoStarted = false;
+
+  const setUpVideo = () => {
+    const onStateChange = (e) => {
+      if (e.data == 1) {
+        if (!videoStarted) {
+          window.analytics.track("screencast_started", {
+            id: embedId,
+            name: title,
+          });
+        }
+        videoStarted = true;
+      }
+    };
+
+    new YT.Player(randomId, {
+      events: { onStateChange },
+    });
+  };
+
+  onMount(() => {
+    if (typeof YT === "undefined") {
+      var tag = document.createElement("script");
+      tag.src = "https://www.youtube.com/iframe_api";
+      var firstScriptTag = document.getElementsByTagName("script")[0];
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+      // Youtube script will automatically call the following function
+      window.onYouTubeIframeAPIReady = () =>
+        window.dispatchEvent(new Event("YouTubeIframeApiReady"));
+
+      window.addEventListener("YouTubeIframeApiReady", () => {
+        setUpVideo();
+      });
+    } else {
+      setUpVideo();
+    }
+  });
 </script>
 
 <style>
@@ -31,7 +82,8 @@
 
 <div class="youtube">
   <iframe
-    src={`https://www.youtube.com/embed/${embedId}`}
+    id={randomId}
+    src={`https://www.youtube.com/embed/${embedId}?enablejsapi=1`}
     {title}
     width="560"
     height="315"

--- a/src/contents/home/index.ts
+++ b/src/contents/home/index.ts
@@ -95,24 +95,28 @@ export const projects: Project[] = [
     title: "Node or TypeScript",
     githubUrl: "https://github.com/gitpod-io/example-typescript-node",
     alt: "Node or TypeScript",
+    trackingName: "node-typescript",
   },
   {
     logo: "svg/projects/python.svg",
     title: "Python",
     githubUrl: "https://github.com/gitpod-io/example-python-django",
     alt: "Python",
+    trackingName: "python",
   },
   {
     logo: "svg/projects/go.svg",
     title: "Go",
     githubUrl: "https://github.com/gitpod-io/example-golang-cli",
     alt: "Go Language",
+    trackingName: "go",
   },
   {
     logo: "svg/projects/rust.svg",
     title: "Rust",
     githubUrl: "https://github.com/gitpod-io/example-rust-cli",
     alt: "Rust",
+    trackingName: "rust",
   },
   {
     logo: "svg/projects/java.svg",
@@ -121,12 +125,14 @@ export const projects: Project[] = [
     gitlabUrl: "https://gitlab.com/gitpod/spring-petclinic",
     bitbucketUrl: "https://bitbucket.org/gitpod/spring-petclinic",
     alt: "Java",
+    trackingName: "java",
   },
   {
     logo: "svg/projects/svelte.svg",
     title: "Svelte",
     githubUrl: "https://github.com/gitpod-io/sveltejs-template",
     alt: "Svelte",
+    trackingName: "svelte",
   },
   // {
   //   logo: "svg/projects/php.svg",

--- a/src/contents/pricing.ts
+++ b/src/contents/pricing.ts
@@ -8,6 +8,7 @@ export const pricingPlans: Pricing[] = [
     features: ["50 hours/month", "Public Repos", "Private Repos 30d Trial"],
     btnText: "Try Now",
     btnHref: "/#get-started",
+    trackingName: "free",
   },
   {
     title: "Personal",
@@ -21,6 +22,7 @@ export const pricingPlans: Pricing[] = [
     ],
     btnText: "Buy Now",
     btnHref: "https://gitpod.io/plans",
+    trackingName: "personal",
   },
   {
     title: "Professional",
@@ -35,6 +37,7 @@ export const pricingPlans: Pricing[] = [
     btnText: "Buy Now",
     btnHref: "https://gitpod.io/plans",
     spiced: true,
+    trackingName: "professional",
   },
   {
     title: "Unleashed",
@@ -48,6 +51,7 @@ export const pricingPlans: Pricing[] = [
     ],
     btnText: "Buy Now",
     btnHref: "https://gitpod.io/plans",
+    trackingName: "unleashed",
   },
 ];
 
@@ -60,6 +64,7 @@ export const otherPlans = [
     ],
     btnText: "Apply now",
     btnHref: "/contact",
+    trackingName: "pro-open-source",
   },
   {
     title: "Self Hosted",
@@ -69,6 +74,7 @@ export const otherPlans = [
     ],
     btnText: "Learn more",
     btnHref: "/self-hosted",
+    trackingName: "self-hosted",
   },
   {
     title: "Student",
@@ -87,5 +93,6 @@ export const otherPlans = [
     ],
     btnText: "Check now",
     btnHref: "https://gitpod.io/plans",
+    trackingName: "student",
   },
 ];

--- a/src/contents/self-hosted.ts
+++ b/src/contents/self-hosted.ts
@@ -8,6 +8,7 @@ export const pricingPlans: Pricing[] = [
     features: ["Unlimited Users", "Public Repos", "Private Repos"],
     btnText: "Install now",
     btnHref: "/docs/self-hosted/latest/self-hosted",
+    trackingName: "free",
   },
   {
     title: "Professional",
@@ -23,5 +24,6 @@ export const pricingPlans: Pricing[] = [
     btnText: "Get License",
     btnHref: "/enterprise-license",
     spiced: true,
+    trackingName: "professional",
   },
 ];

--- a/src/routes/careers.svelte
+++ b/src/routes/careers.svelte
@@ -83,7 +83,14 @@
   <h1>To remove all friction from the developer experience.</h1>
   <p>Bring back joy and speed to dev workflows.</p>
   <p>
-    <a href="#jobs" class="btn-conversion">View {careers.length} openings</a>
+    <a
+      href="#jobs"
+      on:click={() =>
+        window.analytics.track("hiring_interaction", {
+          subtype: "cta_clicked",
+        })}
+      class="btn-conversion">View {careers.length} openings</a
+    >
   </p>
 </header>
 
@@ -173,18 +180,27 @@
     <h2 id="jobs" class="h4 mt-5rem">Open positions</h2>
     <p>
       If there isn't an open position for you but you'd still want to work at
-      Gitpod let us know via <a href="mailto:career@gitpod.io"
-        >career@gitpod.io</a
+      Gitpod let us know via <a
+        href="mailto:career@gitpod.io"
+        on:click={() =>
+          window.analytics.track("hiring_interaction", {
+            subtype: "email_clicked",
+          })}>career@gitpod.io</a
       >
     </p>
 
     <ul class="jobs">
-      {#each careers as career}
+      {#each careers as career, i}
         <li id={hyphenate(career.title)}>
           <button
             bind:this={career.focusEl}
             on:click={() => {
               selectedCareer = career;
+              window.analytics.track("hiring_interaction", {
+                subtype: "position_opened",
+                name: career.title,
+                position: i,
+              });
             }}
           >
             <div class="group flex justify-center items-center text-gray-900">

--- a/src/routes/changelog/index.svelte
+++ b/src/routes/changelog/index.svelte
@@ -52,6 +52,11 @@
       <a
         href="https://www.twitter.com/gitpod"
         rel="noopener"
+        on:click={() =>
+          window.analytics.track("social_opened", {
+            context: "changelog",
+            platform: "twitter",
+          })}
         class="btn-primary">Follow us on Twitter</a
       >
     </p>

--- a/src/routes/contact.svelte
+++ b/src/routes/contact.svelte
@@ -15,11 +15,16 @@
       btnHref: "https://community.gitpod.io",
       btnText: "Open community",
       description:
-        "If you are looking for help for common requests pease visit our community.",
+        "If you are looking for help for common requests please visit our community.",
       title: "Ask the community",
       image: "icon-enter.svg",
       imgHeight: "154",
       imgWidth: "147",
+      tracking: () =>
+        window.analytics.track("social_opened", {
+          context: "body",
+          name: "discourse",
+        }),
     },
     {
       btnHref: "/docs/professional-open-source#who-is-eligible",
@@ -91,6 +96,15 @@
     if (!isFormValid) {
       return;
     }
+
+    window.analytics.identify({
+      name_untrusted: formData.name.value,
+      email_untrusted: formData.email.value,
+    });
+
+    window.analytics.track("message_submitted", {
+      subject: formData.selectedSubject.value,
+    });
 
     const email: Email = {
       from: {

--- a/src/routes/features.svelte
+++ b/src/routes/features.svelte
@@ -155,7 +155,13 @@
       <a
         href="https://www.youtube.com/watch?v=iYLCHQgj0fE"
         rel="noopener"
-        target="_blank">Learn more about sudo/Docker in Gitpod.</a
+        target="_blank"
+        on:click={() =>
+          window.analytics.track("external_resource_clicked", {
+            context: "body",
+            name: "sudo-docker-feature",
+            url: "https://www.youtube.com/watch?v=iYLCHQgj0fE",
+          })}>Learn more about sudo/Docker in Gitpod.</a
       >
     </div>
   </div>

--- a/src/routes/gitpod-vs-github-codespaces.svelte
+++ b/src/routes/gitpod-vs-github-codespaces.svelte
@@ -148,7 +148,12 @@
       <p class="card-image-legend">
         Compared start-up time until ready-to-code for<br /><a
           href="https://github.com/gitpod-io/vscode"
-          ><strong>https://github.com/gitpod-io/vscode</strong></a
+          on:click={() =>
+            window.analytics.track("external_resource_clicked", {
+              name: "vscode-repo",
+              url: "https://github.com/gitpod-io/vscode",
+              context: "body",
+            })}><strong>https://github.com/gitpod-io/vscode</strong></a
         >. Last verified 25 Sep 2020.
       </p>
     </div>
@@ -179,7 +184,13 @@
         Sep 2020.<br />Sources: <a href="/pricing"><strong>Gitpod</strong></a>,
         <a
           href="https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/about-billing-for-codespaces"
-          ><strong>GitHub Codespaces</strong></a
+          on:click={() =>
+            window.analytics.track("external_resource_clicked", {
+              name: "codespaces-resources",
+              url:
+                "https://docs.github.com/en/free-pro-team@latest/github/developing-online-with-codespaces/about-billing-for-codespaces",
+              context: "body",
+            })}><strong>GitHub Codespaces</strong></a
         >.
       </p>
     </div>
@@ -435,6 +446,12 @@
     <p>
       <a
         href="https://cloud.google.com/sustainability"
+        on:click={() =>
+          window.analytics.track("external_resource_clicked", {
+            name: "gcp-sustainability",
+            url: "https://cloud.google.com/sustainability",
+            context: "body",
+          })}
         class="btn-green"
         target="_blank"
         rel="noopener">More on GCP carbon neutral</a

--- a/src/routes/pricing.svelte
+++ b/src/routes/pricing.svelte
@@ -1,5 +1,6 @@
 <script context="module">
   export const prerender = true;
+  const trackingContext = "general";
 </script>
 
 <script>
@@ -18,7 +19,7 @@
     title: "Pricing",
   }}
 />
-<PlansAndPricing />
-<OtherPlans {otherPlans} />
-<Faqs />
+<PlansAndPricing {trackingContext} />
+<OtherPlans {trackingContext} {otherPlans} />
+<Faqs {trackingContext} />
 <Explore />

--- a/src/routes/self-hosted.svelte
+++ b/src/routes/self-hosted.svelte
@@ -1,5 +1,6 @@
 <script context="module">
   export const prerender = true;
+  const trackingContext = "self-hosted";
 </script>
 
 <script>
@@ -15,6 +16,6 @@
     title: "Self-Hosted",
   }}
 />
-<PlansAndPricing />
-<Faqs />
+<PlansAndPricing {trackingContext} />
+<Faqs {trackingContext} />
 <Explore />

--- a/src/types/contact-card.type.ts
+++ b/src/types/contact-card.type.ts
@@ -6,4 +6,5 @@ export type ContactCard = {
   image: string;
   imgHeight: string;
   imgWidth: string;
+  tracking?: () => void;
 };

--- a/src/types/pricing.type.ts
+++ b/src/types/pricing.type.ts
@@ -8,4 +8,5 @@ export type Pricing = {
   spiced?: boolean;
   learnMoreHref?: string;
   footnote?: string;
+  trackingName: string;
 };

--- a/src/types/project.type.ts
+++ b/src/types/project.type.ts
@@ -5,4 +5,5 @@ export type Project = {
   gitlabUrl?: string;
   bitbucketUrl?: string;
   alt: string;
+  trackingName: string;
 };


### PR DESCRIPTION
Implement Segment tracking events described in the tracking plan.

Out of scope:
* `newsletter_signup`

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

