### PR TITLE
Write user-facing descriptions.

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS-FEEDBACK.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS-FEEDBACK.yml
@@ -6,12 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please copy the user feedback from the spreadsheet and provide additional details as needed.
+        Thank you for providing feedback 🙏. We really appreciate it and always work towards better, more helpful docs.
   - type: input
     id: page-url
     attributes:
       label: Page URL
-      description: The "URL" field from the spreadsheet
+      description: The URL of the page you provide feedback for.
       placeholder: ex. https://www.gitpod.io/docs/getting-started
     validations:
       required: true
@@ -19,6 +19,6 @@ body:
     id: feedback
     attributes:
       label: User feedback
-      description: Copy the feedback provided by the user.
+      description: What is your feedback?
     validations:
       required: true


### PR DESCRIPTION
A follow up to #749 with user-facing descriptions.

The previous descriptions were focused on Gitpod team members. However, I managed to create URLs that include values for all fields in the issue form. With that, the docs feedback issue form is auto-populated when Gitpod team members click the "Create issue" link in the Feedback spreadsheet (yay!)

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/750"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

