### PR TITLE
Navigate to the media kit when right-click on logo.

### DIFF
--- a/src/components/main-nav/index.svelte
+++ b/src/components/main-nav/index.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import MobileMenu from "./mobile-menu/index.svelte";
   import MobileMenuToggle from "./mobile-menu/toggle.svelte";
   import NavItem from "./nav-item.svelte";
@@ -33,6 +34,8 @@
       isHighlighted: true,
     },
   ];
+
+  const redirectToMediaKit = () => goto("/media-kit");
 </script>
 
 <style type="text/postcss">
@@ -57,7 +60,12 @@
   class={`${$menuState ? "bg-off-white " : ""}mx-auto w-full`}
 >
   <div class="flex items-center justify-between h-20 px-4 sm:px-8">
-    <a href="/" aria-label="Gitpod" on:click={() => ($menuState = !menuState)}>
+    <a
+      on:contextmenu|preventDefault={redirectToMediaKit}
+      href="/"
+      aria-label="Gitpod"
+      on:click={() => ($menuState = !menuState)}
+    >
       <Logo />
     </a>
     <div class="nav-items hidden px-2 space-x-6 items-center md:space-x-12">

--- a/src/components/main-nav/index.svelte
+++ b/src/components/main-nav/index.svelte
@@ -34,8 +34,6 @@
       isHighlighted: true,
     },
   ];
-
-  const redirectToMediaKit = () => goto("/media-kit");
 </script>
 
 <style type="text/postcss">
@@ -61,7 +59,7 @@
 >
   <div class="flex items-center justify-between h-20 px-4 sm:px-8">
     <a
-      on:contextmenu|preventDefault={redirectToMediaKit}
+      on:contextmenu|preventDefault={() => goto("/media-kit")}
       href="/"
       aria-label="Gitpod"
       on:click={() => ($menuState = !menuState)}


### PR DESCRIPTION
Inspired by Vercel, when someone right-clicks the logo in the header, it navigates to the media kit page.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/752"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

