### PR TITLE
fix(media-kit): founders image not being displayed

### DIFF
--- a/src/components/media-kit/founders.svelte
+++ b/src/components/media-kit/founders.svelte
@@ -9,10 +9,10 @@
   <div
     class="shadow-normal rounded-4xl bg-white p-small sm:p-x-large mb-x-large"
   >
-    <img src="imgSrc" alt="Gitpod founders group" class="rounded-4xl mx-auto" />
+    <img src={imgSrc} alt="Gitpod founders group" class="rounded-4xl mx-auto" />
     <p class="py-xx-small">Download founder group picture</p>
     <a
-      href="imgSrc"
+      href={imgSrc}
       on:click={() =>
         window.analytics.track("media_downloaded", {
           name: imgSrc,


### PR DESCRIPTION
fixes #781
![image](https://user-images.githubusercontent.com/51229945/126985791-9dcdc48a-2773-4a2c-bc88-4f324a5333d4.png)


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/788"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

