### PR TITLE
Add teams and projects docs

### DIFF
--- a/src/routes/docs/menu.ts
+++ b/src/routes/docs/menu.ts
@@ -46,7 +46,7 @@ export const MENU: MenuEntry[] = [
     M("Life of a workspace", "life-of-workspace"),
     M("Contexts", "context-urls"),
     M("Collaboration & Sharing", "sharing-and-collaboration"),
-    M("Create a team", "teams"),
+    M("Teams & Projects", "teams-and-projects"),
     M("Local Companion", "develop/local-companion"),
   ]),
   M("Integrations", "integrations", [

--- a/src/routes/docs/teams-and-projects.md
+++ b/src/routes/docs/teams-and-projects.md
@@ -1,0 +1,12 @@
+---
+section: develop
+title: Create a Team
+---
+
+<script context="module">
+  export const prerender = true;
+</script>
+
+# Teams & Projects
+
+// TODO

--- a/src/routes/docs/teams.md
+++ b/src/routes/docs/teams.md
@@ -7,6 +7,9 @@ title: Create a Team
   export const prerender = true;
 </script>
 
+> **DEPRECATION NOTICE** —
+> Hey! We're introducing <strong>Teams & Projects</strong> to surface <strong>Prebuilds</strong> in the dashboard. All existing teams will be migrated over the upcoming weeks. There's no action required on your side. <a href="/docs/teams-and-projects" className="learn-more">Learn more about Teams & Projects</a>.
+
 # Create a Team
 
 From [gitpod.io/teams/](https://gitpod.io/teams/), you can create a team and manage subscriptions for your team members with centralized billing.


### PR DESCRIPTION
1. Add a deprecation notice on top of the Teams documentation ([`/docs/teams`](https://www.gitpod.io/docs/teams)) following the changes in https://github.com/gitpod-io/gitpod/pull/5121.
1. Replace the Teams menu item with a Teams & Projects menu item.
1. Add Teams & Projects documentation (WIP)