### PR TITLE
Rename teams to team plans

### DIFF
--- a/src/components/pricing/faqs.svelte
+++ b/src/components/pricing/faqs.svelte
@@ -61,11 +61,11 @@
         <img src="/svg/brands/visa.svg" alt="Visa" width="72" height="40" />
       </div>
     </Faq>
-    <Faq title="Can I create a team account?" {trackingContext}>
+    <Faq title="Can I create a team plan?" {trackingContext}>
       <p>
         Sure, if you would like to manage subscriptions for a whole team on a
         single invoice, you can create a{" "}
-        <a href="https://gitpod.io/teams/">team subscription.</a>
+        <a href="https://gitpod.io/teams/">team plan.</a>
       </p>
       <p>
         In case you need more information on how to setup a team subscription,

--- a/src/components/self-hosted/faqs.svelte
+++ b/src/components/self-hosted/faqs.svelte
@@ -15,7 +15,7 @@
 <Section>
   <Faqs>
     <h2 class="h1">FAQs</h2>
-    <Faq title="Can I create a team account?" {trackingContext}>
+    <Faq title="Can I create a team plan?" {trackingContext}>
       <p>
         Of course! You can use Gitpod Self-Hosted on your own infrastructure for
         free for unlimited users. If you'd like to access additional features

--- a/src/routes/docs/develop/index.md
+++ b/src/routes/docs/develop/index.md
@@ -15,6 +15,6 @@ The following links describe how to develop on Gitpod and elaborate on topics br
 - [Life of a workspace](/docs/life-of-workspace)
 - [Contexts](/docs/context-urls)
 - [Collaboration & Sharing](/docs/sharing-and-collaboration)
-- [Create a team](/docs/teams)
+- [Create a team plan](/docs/teams)
 - [Local Companion](/docs/develop/local-companion)
 - [VS Code Desktop Support](/docs/develop/vscode-desktop-support)

--- a/src/routes/docs/menu.ts
+++ b/src/routes/docs/menu.ts
@@ -62,7 +62,7 @@ export const MENU: MenuEntry[] = [
     M("Life of a workspace", "life-of-workspace"),
     M("Contexts", "context-urls"),
     M("Collaboration & Sharing", "sharing-and-collaboration"),
-    M("Create a team", "teams"),
+    M("Create a team plan", "teams"),
     M("Local Companion", "develop/local-companion"),
     M("VS Code Desktop Support", "develop/vscode-desktop-support"),
   ]),

--- a/src/routes/docs/teams.md
+++ b/src/routes/docs/teams.md
@@ -1,17 +1,15 @@
 ---
 section: develop
-title: Create a Team
+title: Create a Team Plan
 ---
 
 <script context="module">
   export const prerender = true;
 </script>
 
-# Create a Team
+# Create a Team Plan
 
-From [gitpod.io/teams/](https://gitpod.io/teams/), you can create a team and manage subscriptions for your team members with centralized billing.
-
-![Teams List](../../../static/images/docs/teams-list.jpg)
+From [gitpod.io/teams/](https://gitpod.io/teams/), you can create team plans and manage subscriptions for your team members with centralized billing.
 
 If you don’t have a Gitpod account yet, you’ll be asked to create one first. You can choose between the Team Professional or Team Unleashed plan and how many seats you want for each team.
 
@@ -31,5 +29,5 @@ You can either directly assign a seat by entering your team member's GitHub user
 
 ## Good to know
 
-- You don’t need to have a subscription yourself in order to manage seats for your team. You can simply sign in to https://gitpod.io/teams/ for free.
+- You don’t need to have a subscription yourself in order to manage seats for your team plan. You can simply sign in to https://gitpod.io/teams/ for free.
 - If you’d like to add more seats, delete seats or reassign existing seats, you can do these changes at any time.


### PR DESCRIPTION
This is a follow up PR for https://github.com/gitpod-io/gitpod/pull/6011.