### PR TITLE
make sure that the logo does not appear to be cut at the end.

### DIFF
--- a/src/components/screencasts/preview.svelte
+++ b/src/components/screencasts/preview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { stringToBeautifiedFragment } from "../../utils/helpers";
   import type { Screencast } from "../../types/screencasts.type";
-  import Logo from "../svgs/logo.svelte";
 
   export let screencast: Screencast;
   export let screencastNumber: number;
@@ -26,6 +25,11 @@
     {:else}
       <h2>{screencast.title}</h2>
     {/if}
-    <Logo />
+    <img
+      src="/svg/media-kit/logo-light-theme.svg"
+      height="40"
+      width="85"
+      alt="Gitpod"
+    />
   </div>
 </a>


### PR DESCRIPTION
Fixes Broken layout for Screencasts #1036

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/46004116/136084991-b0f63c80-f828-4f63-b9c3-6e419c64510a.png) |  ![image](https://user-images.githubusercontent.com/46004116/136085071-87bf8f90-eca2-4435-bc76-0f2a2884d9c1.png) |