### PR TITLE
Docs update for contribution with Gitpod. 

### DIFF
--- a/src/routes/docs/contribute/features-and-patches/submitting-a-pull-request.md
+++ b/src/routes/docs/contribute/features-and-patches/submitting-a-pull-request.md
@@ -51,3 +51,23 @@ If we suggest changes, then:
 - Push the changes to your GitHub repository (this will update your Pull Request).
 
 That's it! Thank you for your contribution!
+
+&nbsp;
+
+# [Optional] Submitting a pull request with Gitpod
+
+Before you submit your pull request, please:
+
+- If you are considering submitting a pull-request that is more than a simple fix, open a discussion on GitHub first with your proposal.
+- Search [GitHub](https://github.com/gitpod-io/gitpod/pulls) for an open or closed Pull Request that relates to your submission.
+
+- Sign the [Contributor License Agrement](https://www.gitpod.io/cla) if prompted by the robots.
+
+If we suggest changes, then:
+
+- Make the required updates.
+- Re-run the test suite to ensure tests are still passing.
+- Commit your changes to your branch (e.g. `my-fix-branch`).
+- Push the changes to your GitHub repository (this will update your Pull Request).
+
+That's it! Thank you for your contribution!

--- a/src/routes/docs/contribute/features-and-patches/submitting-a-pull-request.md
+++ b/src/routes/docs/contribute/features-and-patches/submitting-a-pull-request.md
@@ -52,9 +52,7 @@ If we suggest changes, then:
 
 That's it! Thank you for your contribution!
 
-&nbsp;
-
-# [Optional] Submitting a pull request with Gitpod
+## [Optional] Submitting a pull request with Gitpod
 
 Before you submit your pull request, please:
 


### PR DESCRIPTION
## Description
I want to make sure that I understand the work correctly. Do you want me to create an additional page, "How to contribute with Gitpod? " or do you want me to leave as I did an "Optional." 
I will rewrite the file with better instructions on how to contribute with ```https://gitpod.io/#https://github.com/:username/gitpod```

## Related Issue(s)

Relates to #1214 

## How to test
## Release Notes
## Documentation



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1219"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

