### PR TITLE
fix: update wording for workspace deletion

### DIFF
--- a/src/routes/docs/life-of-workspace.md
+++ b/src/routes/docs/life-of-workspace.md
@@ -40,7 +40,7 @@ Not to worry, your changes are safe. You can navigate back to https://gitpod.io,
 
 Old, unused workspaces are automatically deleted.
 
-Unused workspaces are deleted on a schedule. There is no fixed amount of workspaces that are kept by Gitpod. To know exactly how long your past workspaces will be kept, a message is displayed at the top of the [workspaces list](https://gitpod.io/workspaces/) in your dashboard (the exact number of days may change in the future). Restarting a workspace resets the day counter for this particular workspace.
+Unused workspaces are deleted on a schedule. There is no fixed amount of workspaces that are kept by Gitpod. To know exactly how long your past workspaces will be kept, a message is displayed at the top of the [workspaces list](https://gitpod.io/workspaces/) in your dashboard. Restarting a workspace resets the day counter for this particular workspace.
 
 To prevent a workspace from being deleted, you can pin it in your [list of workspaces](https://gitpod.io/workspaces/). Pinned workspaces are kept forever.
 

--- a/src/routes/docs/life-of-workspace.md
+++ b/src/routes/docs/life-of-workspace.md
@@ -38,7 +38,11 @@ Not to worry, your changes are safe. You can navigate back to https://gitpod.io,
 
 ## Garbage Collection
 
-Old, unused workspaces are automatically deleted. To prevent a workspace from being deleted, you can pin it in your [list of workspaces](https://gitpod.io/workspaces/). Pinned workspaces are kept forever. A message at the top of the workspaces list indicates after how many days unused and unpinned workspaces will get collected (the exact number of days may change in the future). Restarting a workspace resets the day counter for this particular workspace.
+Old, unused workspaces are automatically deleted.
+
+Unused workspaces are deleted on a schedule. There is no fixed amount of workspaces that are kept by Gitpod. To know exactly how long your past workspaces will be kept, a message is displayed at the top of the [workspaces list](https://gitpod.io/workspaces/) in your dashboard (the exact number of days may change in the future). Restarting a workspace resets the day counter for this particular workspace.
+
+To prevent a workspace from being deleted, you can pin it in your [list of workspaces](https://gitpod.io/workspaces/). Pinned workspaces are kept forever.
 
 ## Changes are Saved
 


### PR DESCRIPTION
## Description

Small wording suggestion to make it a bit clearer that workspace deletion is time-based and not based on a number of old workspaces. 

## Related Issue(s)

N/A

## How to test

* Open in Gitpod
* Navigate to: https://www.gitpod.io/docs/life-of-workspace

## Release Notes

N/A

## Documentation

N/A


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1223"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

