### PR TITLE
fix: point troubleshooting to correct section

### DIFF
--- a/src/routes/docs/troubleshooting.md
+++ b/src/routes/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-section: references
+section: troubleshooting
 title: Troubleshooting
 ---
 


### PR DESCRIPTION
## Description

Fixing a small bug: clicking on references in the docs currently highlights the wrong section on the left. 

This fixes that 🙏 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1244"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

