### PR TITLE
Add PlanetScale quickstart guide

### DIFF
--- a/src/routes/docs/quickstart/planetscale.md
+++ b/src/routes/docs/quickstart/planetscale.md
@@ -1,0 +1,78 @@
+---
+section: quickstart
+title: PlanetScale template
+---
+
+<script context="module">
+  export const prerender = true;
+</script>
+
+# PlanetScale Quickstart
+
+Learn how to set-up and understand the benefits of Gitpod **in less than 5 min** with our [PlanetScale](https://github.com/Shulammite-Aso/template-planetscale) template.
+
+The following guide will:
+
+- Walk you through a real world example with an existing Gitpod config
+- Introduce you to prebuilds
+- Demonstrate the benefits of ephemeral developer environments
+
+For simplicity we use a GitHub template, but Gitpod works similarly with GitLab and Bitbucket.
+
+## Step 1: Clone Git repository
+
+- Create a new repository based on the [PlanetScale template](https://github.com/Shulammite-Aso/template-planetscale/generate).
+- Name it e.g. `my-planetscale-template`.
+
+## Step 2: Install the Gitpod app
+
+- Install the [Gitpod App](https://github.com/apps/gitpod-io/installations/new).
+
+  Gitpod's GitHub app is similar to a CI server and will continuously prepare prebuilds for all your branches and pull requests - so you don't have to wait for Maven or NPM downloading the internet when you want to start coding.
+
+## Step 3: First prebuild
+
+- Start your first workspace with a prebuild by prefixing **https://gitpod.io#prebuild/** to the URL of the repository.
+
+The revised URL is: `https://gitpod.io/#prebuild/https://github.com/<github_username>/<my-planetscale-template>`
+
+Gitpod displays the prebuild progress status by running the `init` commands in the _.gitpod.yml_ file before you even start a workspace. Later, when you create a new workspace on a branch, or pull/merge request the workspace loads much faster, because all dependencies are already downloaded and the code is compiled. For more information see [prebuilds](/docs/prebuilds).
+
+## Step 4: Enjoy being ready-to-code 🤙
+
+Once the first prebuild ran, Gitpod starts an automated and fully configured developer environment in a workspace that is now ready for you to develop.
+
+Other developers made their setup even more productive and supercharged their workflows with the following quick steps:
+
+1. **Installing the browser extension**
+
+You can install the Gitpod browser extension on any [Chromium-based](https://chrome.google.com/webstore/detail/gitpod-online-ide/dodmmooeoklaejobgleioelladacbeki) browsers such as Microsoft Edge, Brave, Chrome, and others, or on a [Firefox](https://addons.mozilla.org/firefox/addon/gitpod/) browser.
+
+The extension simply adds a Gitpod button on every project and branch across GitHub, and Bitbucket that prefixes the URL with `gitpod.io/#` so that you can easily open a new workspace from any Git context.
+
+![Browser Extension](../../../static/images/docs/browser-extension-lense.png)
+
+If you prefer to not install browser extensions then you can use the Gitpod [browser bookmarklet](/docs/browser-bookmarklet) instead.
+
+For our partner GitLab we have a native integration into their UI that you can enable here.
+
+2. **Add your favorite VS Code themes and extensions**
+
+You have access to all Visual Studio Code extensions published under the vendor neutral [Open VSX registry](https://open-vsx.org/). Install one by clicking the Extensions icon in the left sidebar and enter your favorite theme or VS Code extension.
+
+Changes you make in your workspace such as themes and extensions are synced automatically to other workspaces.
+
+3. **Start throwing away workspaces like paper towels**
+
+You can now start to treat dev environments as automated resources you spin up when you need them and close down (and forget about) when you are done with your task. Dev environments become fully ephemeral.
+
+You even can start switching between workspaces or open several workspaces on the same context - two for your feature, one for reviewing a PR/MR, one for a bug, one for another MR/PR.
+
+Try it out and open 3 workspaces on the same context (e.g. on main or on an issue). 🤓
+
+## Next Steps
+
+You've successfully ran your first workspace and experienced first hand what we mean with ephemeral dev environments. This is just the first step on your journey towards being always ready to code. Helpful resources from here are:
+
+- [Getting started with your own project](/docs/configure)
+- [Git Integrations](/docs/integrations)

--- a/src/stores/quickstarts.ts
+++ b/src/stores/quickstarts.ts
@@ -55,6 +55,7 @@ const quickstartItems = readable(
     mapQuickstart("Perl", "quickstart/perl", false),
     mapQuickstart("PHP Drupal", "quickstart/drupal", false),
     mapQuickstart("PHP Laravel", "quickstart/laravel", false),
+    mapQuickstart("PlanetScale", "quickstart/planetscale", false),
     mapQuickstart(
       "Python Django",
       "quickstart/python",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a quickstart guide for [PlanetScale](https://planetscale.com/). 
For the template linked on the guide, the .gitpod.yml file pulls the docker image for PlanetScale CLI(pscale ) then creates  a shell alias that runs the latest version of pscale from docker whenever the user runs a `pscale` command.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1259"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

