### PR TITLE
[Analytics] Fix that Website overwrites anonymous_id set by dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,15 @@
     "@sendgrid/mail": "^7.5.0",
     "@slack/webhook": "^6.0.0",
     "emoji-regex": "^10.0.0",
-    "google-spreadsheet": "^3.1.15"
+    "google-spreadsheet": "^3.1.15",
+    "js-cookie": "^3.0.1"
   },
   "devDependencies": {
     "@netlify/functions": "^0.8.0",
     "@sveltejs/adapter-netlify": "^1.0.0-next.35",
     "@sveltejs/kit": "^1.0.0-next.188",
     "@tsconfig/svelte": "^2.0.1",
+    "@types/js-cookie": "^3.0.1",
     "autoprefixer": "^10.4.0",
     "cssnano": "^5.0.8",
     "encoding": "^0.1.13",

--- a/src/components/segment.svelte
+++ b/src/components/segment.svelte
@@ -3,6 +3,7 @@
     interface Window {
       analytics: any;
       doNotTrack: any;
+      localStorage: any;
     }
   }
 </script>
@@ -10,6 +11,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { page } from "$app/stores";
+  import Cookies from "js-cookie";
 
   const writeKey =
     typeof window !== "undefined" &&
@@ -26,6 +28,12 @@
       navigator.doNotTrack === "yes");
 
   onMount(async () => {
+    // Override anonymous ID in local storage if it exists in Cookie
+    // This is done in order to guarantee the same anonymous_id is used by dashboard and website
+    const current_id = Cookies.get("ajs_anonymous_id");
+    if (current_id) {
+      window.localStorage.setItem("ajs_anonymous_id", current_id);
+    }
     // Create a queue, but don't obliterate an existing one!
     var analytics = (window.analytics = window.analytics || []);
     // If the real analytics.js is already on the page return.


### PR DESCRIPTION
## Description
Fixes Analytics Bug caused by Segment's Analytics.js library overwriting `ajs_anonymous_id` set by dashboard with the value that is persisted in local storage by checking whether an anonymous ID is contained in cookie and writing it to local storage.

## How to test
- Ensure that Segment's Website Staging Source is enabled
- Open any Gitpod page on the dev server
- Check that the page call is recorded on Segment's Website Staging source
- By clicking on the page call and then `raw` on the detail tab, the `anonymousId` is displayed
- Now change the `ajs_anonymous_id` Cookie set for the Workspace's domain to another value (Developer Tools -> Applications -> Cookies)
- Reload the page and check that the new page call in Segment contains the changed ID in its payload