### PR TITLE
Jh/track-startup-program

### DIFF
--- a/src/components/startups/header.svelte
+++ b/src/components/startups/header.svelte
@@ -13,8 +13,14 @@
   >
     Use all our services for free, up to 2 years.
   </p>
-  <a href="https://bit.ly/3liFICY" target="_blank" class="btn-conversion"
-    >Apply now</a
+  <a
+    href="https://docs.google.com/forms/d/e/1FAIpQLSc-Vaelz0yG-XkuN2CYyUtZz0khhwMaju4oSLdMNIzoMkpHug/viewform"
+    on:click={() =>
+      window.analytics.track("startup_application_opened", {
+        context: "hero",
+      })}
+    target="_blank"
+    class="btn-conversion">Apply now</a
   >
   <Quote />
 </header>

--- a/src/routes/blog/gitpod-for-startups.md
+++ b/src/routes/blog/gitpod-for-startups.md
@@ -43,6 +43,6 @@ Your startup is eligible if it was founded less than 3y ago, has raised a maximu
 
 ## How do I apply?
 
-Give it a try and fill out the [application form](https://bit.ly/3anDmwd). Once you’re part of the program, you’ll get the chance for a personal onboarding call with our community engineers. Check out our [website](/for/startups) for more details.
+Check out our [website](/for/startups) for more details and the link to the application form. Once you’re part of the program, you’ll get the chance for a personal onboarding call with our community engineers.
 
 Want to share program details with your colleagues or other startups? This [Notion page](https://bit.ly/Gitpod-for-startups-notion) might be handy.


### PR DESCRIPTION
Two changes are introduced
- Button `Apply now` in [/for/startups](https://www.gitpod.io/for/startups) is tracked so that we can measure conversions
- The wording in [/blog/gitpod-for-startups](https://www.gitpod.io/blog/gitpod-for-startups) is adapted to no longer directly redirect to the application form but instead funnel visitors through [/for/startups](https://www.gitpod.io/for/startups)

How to test
- Ensure that Website Staging source in Segment is turned on
- Click on `Apply now` in [/for/startups](https://www.gitpod.io/for/startups)
- Ensure that the segment event is coming through in the debugger