### PR TITLE
fix(support): remove references to the discord forum

### DIFF
--- a/src/contents/support.ts
+++ b/src/contents/support.ts
@@ -27,14 +27,6 @@ export const resources: Resource[] = [
     },
   },
   {
-    title: "Community Forum",
-    text: "If you are looking for help with common requests, connect with our community on Discord.",
-    link: {
-      href: "https://community.gitpod.io/",
-      text: "View forum",
-    },
-  },
-  {
     title: "Discord Server",
     text: "Would you like to take part in live coding sessions and connect with the community ? Then join us on Discord.",
     link: {

--- a/src/contents/support.ts
+++ b/src/contents/support.ts
@@ -28,7 +28,7 @@ export const resources: Resource[] = [
   },
   {
     title: "Community Forum",
-    text: "If you are looking for help with common requests, connect with our community on Discourse.",
+    text: "If you are looking for help with common requests, connect with our community on Discord.",
     link: {
       href: "https://community.gitpod.io/",
       text: "View forum",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Renaming Discourse to Discord on Support page.

There are still other lingering cases, but I was just showing this for the purpose of a video demostration

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #1331

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1332"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

