### PR TITLE
index/section-ides: correct Browser/Desktop label

### DIFF
--- a/src/lib/components/index/section-ides.svelte
+++ b/src/lib/components/index/section-ides.svelte
@@ -32,8 +32,8 @@
     <div class="max-w-5xl mx-auto">
       <Toggle
         class="mt-x-small mb-macro"
-        labelLeft="Desktop"
-        labelRight="Browser"
+        labelLeft="Browser"
+        labelRight="Desktop"
         on:change={(e) => {
           ideType = "desktop";
           // @ts-ignore


### PR DESCRIPTION
## Description
The 'toggleChecked' state refers to the right hand side of the toggle.
The code assigns ideType to 'desktop' if toggled, so the right hand side
has to be labeled "Desktop", not "Browser". Vice-versa for the other
side.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
(Didn't file one)

## How to test
Load the website and scroll to "Your environment, your tools, your craft" section. Toggle between Browser and Desktop. The toggle label should correspond to the screenshot below (assuming VS Code is selected by default, the browser one is the one with an address bar).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
N/A?

## Documentation
N/A?
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1406"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

