### PR TITLE
Updated wording at gitpod.io/security

### DIFF
--- a/src/lib/contents/security.ts
+++ b/src/lib/contents/security.ts
@@ -11,7 +11,7 @@ export const programFeatures: ProgramFeature[] = [
   {
     title: "Compliance",
     paragraphs: [
-      "Gitpod is a European company committed to developer and data privacy. We provide our users with the ability to access and control the information that we collect about them.",
+      "Gitpod is a European company committed to security and data privacy. We provide our users with the ability to access and control the information that we collect about them.",
       "Gitpod is built with security in mind and we continuously invest in security best practices. We are currently in the process of becoming SOC 2 compliant and you can request a copy of our SOC2 audit report as soon as it's available.",
     ],
     image: "compliance.svg",


### PR DESCRIPTION
At gitpod.io/security we say we are committed to "developer and data privacy" which has been updated to "security and data privacy" which better fits into the compliance context.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

