### PR TITLE
Use Lite-YT-Embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@slack/webhook": "^6.0.0",
         "emoji-regex": "^10.0.0",
         "google-spreadsheet": "^3.1.15",
-        "js-cookie": "^3.0.1"
+        "js-cookie": "^3.0.1",
+        "lite-youtube-embed": "^0.2.0"
       },
       "devDependencies": {
         "@jsdevtools/rehype-toc": "^3.0.2",
@@ -2803,6 +2804,11 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
+    },
+    "node_modules/lite-youtube-embed": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.2.0.tgz",
+      "integrity": "sha512-XXXAk5sbvtjjwbie3XG+6HppgTm1HTGL/Uk9z9NkJH53o7puZLur434heHzAjkS60hZB3vT4ls25zl5rMiX4EA=="
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -8149,6 +8155,11 @@
           "dev": true
         }
       }
+    },
+    "lite-youtube-embed": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lite-youtube-embed/-/lite-youtube-embed-0.2.0.tgz",
+      "integrity": "sha512-XXXAk5sbvtjjwbie3XG+6HppgTm1HTGL/Uk9z9NkJH53o7puZLur434heHzAjkS60hZB3vT4ls25zl5rMiX4EA=="
     },
     "load-json-file": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@slack/webhook": "^6.0.0",
     "emoji-regex": "^10.0.0",
     "google-spreadsheet": "^3.1.15",
-    "js-cookie": "^3.0.1"
+    "js-cookie": "^3.0.1",
+    "lite-youtube-embed": "^0.2.0"
   },
   "devDependencies": {
     "@jsdevtools/rehype-toc": "^3.0.2",

--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <meta name="theme-color" content="#333333" />
     <meta name="google-site-verification" content="NBio3hCkfn2FKJpqZritJpXuyKo54noPGZzWsjDIp-M" />
-
+    <script src="/lite-yt-embed.js"></script>
     <script>
       if (window.location.pathname.length <= 1 && window.location.hash.indexOf("https://") > -1) {
         window.location.replace("https://gitpod.io/" + window.location.hash);
@@ -14,6 +14,7 @@
 
     <link rel="preload" as="font" href="/fonts/ABCDiatype-Regular.woff" type="font/woff2" crossorigin="anonymous">
     <link rel="preload" as="font" href="/fonts/ABCDiatype-Bold.woff" type="font/woff2" crossorigin="anonymous">
+    <link rel="stylesheet" href="/lite-yt-embed.css" />
     <link rel="stylesheet" rel="preload" href="/font.css" as="style" />
     <link rel="stylesheet" href="/global.css" />
     <link rel="stylesheet" href="/styles.css" />

--- a/src/lib/components/youtube-embed.svelte
+++ b/src/lib/components/youtube-embed.svelte
@@ -13,14 +13,14 @@
   export let embedId: string;
   export let title: string;
 
-  const eventTracker = () => {
-    trackEvent("screencast_started", {
-      id: embedId,
-      name: title,
-      url: window.location.href,
-      path: window.location.pathname,
-    });
-  };
+  // const eventTracker = () => {
+  //   trackEvent("screencast_started", {
+  //     id: embedId,
+  //     name: title,
+  //     url: window.location.href,
+  //     path: window.location.pathname,
+  //   });
+  // };
 </script>
 
 <div class="flex justify-center">

--- a/src/lib/components/youtube-embed.svelte
+++ b/src/lib/components/youtube-embed.svelte
@@ -8,89 +8,25 @@
 </script>
 
 <script lang="ts">
-  import { afterUpdate } from "svelte";
   import { trackEvent } from "./segment.svelte";
 
   export let embedId: string;
   export let title: string;
 
-  const randomId = "yt-player-" + Math.random().toString(36).slice(2, 5);
-  const VIDEO_PLAYING = 1;
-  let videoStarted = false;
-
-  const setUpVideo = () => {
-    const onStateChange = (e: any) => {
-      if (e.data == VIDEO_PLAYING) {
-        if (!videoStarted) {
-          trackEvent("screencast_started", {
-            id: embedId,
-            name: title,
-            url: window.location.href,
-            path: window.location.pathname,
-          });
-        }
-        videoStarted = true;
-      }
-    };
-
-    new YT.Player(randomId, {
-      events: { onStateChange },
+  const eventTracker = () => {
+    trackEvent("screencast_started", {
+      id: embedId,
+      name: title,
+      url: window.location.href,
+      path: window.location.pathname,
     });
   };
-
-  afterUpdate(() => {
-    if (typeof YT === "undefined") {
-      var tag = document.createElement("script");
-      tag.src = "https://www.youtube.com/iframe_api";
-      var firstScriptTag = document.getElementsByTagName("script")[0];
-      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-      // Youtube script will automatically call the following function
-      window.onYouTubeIframeAPIReady = () => {
-        setUpVideo();
-      };
-    } else {
-      videoStarted = false;
-      setUpVideo();
-    }
-  });
 </script>
 
-<style>
-  .youtube {
-    position: relative;
-    overflow: hidden;
-    max-width: 100%;
-    max-height: 500px;
-    width: 880px;
-    margin: auto;
-  }
-
-  .youtube::after {
-    display: block;
-    content: "";
-    padding-top: 56.25%;
-  }
-
-  iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-  }
-</style>
-
-<div class="youtube">
-  <iframe
-    id={randomId}
-    src={`https://www.youtube.com/embed/${embedId}?enablejsapi=1`}
-    {title}
-    width="560"
-    height="315"
-    frameBorder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
+<div class="flex justify-center">
+  <lite-youtube
+    style="width: 100%; heigh: auto; background-image: url('https://i.ytimg.com/vi/{embedId}/hqdefault.jpg');"
+    videoid={embedId}
+    playlabel={title}
   />
 </div>

--- a/src/lib/components/youtube-embed.svelte
+++ b/src/lib/components/youtube-embed.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <script lang="ts">
-  import { trackEvent } from "./segment.svelte";
+  // import { trackEvent } from "./segment.svelte";
 
   export let embedId: string;
   export let title: string;

--- a/static/lite-yt-embed.css
+++ b/static/lite-yt-embed.css
@@ -1,0 +1,89 @@
+lite-youtube {
+  background-color: #000;
+  position: relative;
+  display: block;
+  contain: content;
+  background-position: center center;
+  background-size: cover;
+  cursor: pointer;
+  max-width: 720px;
+}
+
+/* gradient */
+lite-youtube::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.7),
+    rgba(0, 0, 0, 0.01)
+  );
+  background-position: top;
+  background-repeat: repeat-x;
+  height: 60px;
+  padding-bottom: 50px;
+  width: 100%;
+  transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+  thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
+/* play button */
+lite-youtube > .lty-playbtn {
+  width: 68px;
+  height: 48px;
+  position: absolute;
+  cursor: pointer;
+  transform: translate3d(-50%, -50%, 0);
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  background-color: transparent;
+  /* YT's actual play button svg */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  filter: grayscale(100%);
+  transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+  border: none;
+}
+
+lite-youtube:hover > .lty-playbtn,
+lite-youtube .lty-playbtn:focus {
+  filter: none;
+}
+
+/* Post-click styles */
+lite-youtube.lyt-activated {
+  cursor: unset;
+}
+lite-youtube.lyt-activated::before,
+lite-youtube.lyt-activated > .lty-playbtn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lyt-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/static/lite-yt-embed.js
+++ b/static/lite-yt-embed.js
@@ -1,0 +1,133 @@
+/**
+ * A lightweight youtube embed. Still should feel the same to the user, just MUCH faster to initialize and paint.
+ *
+ * Thx to these as the inspiration
+ *   https://storage.googleapis.com/amp-vs-non-amp/youtube-lazy.html
+ *   https://autoplay-youtube-player.glitch.me/
+ *
+ * Once built it, I also found these:
+ *   https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube (👍👍)
+ *   https://github.com/Daugilas/lazyYT
+ *   https://github.com/vb/lazyframe
+ */
+class LiteYTEmbed extends HTMLElement {
+  connectedCallback() {
+    this.videoId = this.getAttribute("videoid");
+
+    let playBtnEl = this.querySelector(".lty-playbtn");
+    // A label for the button takes priority over a [playlabel] attribute on the custom-element
+    this.playLabel =
+      (playBtnEl && playBtnEl.textContent.trim()) ||
+      this.getAttribute("playlabel") ||
+      "Play";
+
+    /**
+     * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
+     *
+     * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+     *
+     * TODO: Do the sddefault->hqdefault fallback
+     *       - When doing this, apply referrerpolicy (https://github.com/ampproject/amphtml/pull/3940)
+     * TODO: Consider using webp if supported, falling back to jpg
+     */
+    if (!this.style.backgroundImage) {
+      this.style.backgroundImage = `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`;
+    }
+
+    // Set up play button, and its visually hidden label
+    if (!playBtnEl) {
+      playBtnEl = document.createElement("button");
+      playBtnEl.type = "button";
+      playBtnEl.classList.add("lty-playbtn");
+      this.append(playBtnEl);
+    }
+    if (!playBtnEl.textContent) {
+      const playBtnLabelEl = document.createElement("span");
+      playBtnLabelEl.className = "lyt-visually-hidden";
+      playBtnLabelEl.textContent = this.playLabel;
+      playBtnEl.append(playBtnLabelEl);
+    }
+
+    // On hover (or tap), warm up the TCP connections we're (likely) about to use.
+    this.addEventListener("pointerover", LiteYTEmbed.warmConnections, {
+      once: true,
+    });
+
+    // Once the user clicks, add the real iframe and drop our play button
+    // TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
+    //   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
+    this.addEventListener("click", this.addIframe);
+  }
+
+  // // TODO: Support the the user changing the [videoid] attribute
+  // attributeChangedCallback() {
+  // }
+
+  /**
+   * Add a <link rel={preload | preconnect} ...> to the head
+   */
+  static addPrefetch(kind, url, as) {
+    const linkEl = document.createElement("link");
+    linkEl.rel = kind;
+    linkEl.href = url;
+    if (as) {
+      linkEl.as = as;
+    }
+    document.head.append(linkEl);
+  }
+
+  /**
+   * Begin pre-connecting to warm up the iframe load
+   * Since the embed's network requests load within its iframe,
+   *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+   * So, the best we can do is warm up a few connections to origins that are in the critical path.
+   *
+   * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+   * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+   */
+  static warmConnections() {
+    if (LiteYTEmbed.preconnected) return;
+
+    // The iframe document and most of its subresources come right off youtube.com
+    LiteYTEmbed.addPrefetch("preconnect", "https://www.youtube-nocookie.com");
+    // The botguard script is fetched off from google.com
+    LiteYTEmbed.addPrefetch("preconnect", "https://www.google.com");
+
+    // Not certain if these ad related domains are in the critical path. Could verify with domain-specific throttling.
+    LiteYTEmbed.addPrefetch(
+      "preconnect",
+      "https://googleads.g.doubleclick.net"
+    );
+    LiteYTEmbed.addPrefetch("preconnect", "https://static.doubleclick.net");
+
+    LiteYTEmbed.preconnected = true;
+  }
+
+  addIframe() {
+    if (this.classList.contains("lyt-activated")) return;
+    this.classList.add("lyt-activated");
+
+    const params = new URLSearchParams(this.getAttribute("params") || []);
+    params.append("autoplay", "1");
+
+    const iframeEl = document.createElement("iframe");
+    iframeEl.width = 560;
+    iframeEl.height = 315;
+    // No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
+    iframeEl.title = this.playLabel;
+    iframeEl.allow =
+      "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture";
+    iframeEl.allowFullscreen = true;
+    // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
+    // https://stackoverflow.com/q/64959723/89484
+    iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(
+      this.videoId
+    )}?${params.toString()}`;
+    this.append(iframeEl);
+
+    // Set focus for a11y
+    iframeEl.focus();
+  }
+}
+// Register custom element
+customElements.define("lite-youtube", LiteYTEmbed);


### PR DESCRIPTION
closes #1175 

I had a play with it. Let me share my thoughts: 
- The Package provides a web-component which generates several other elements under the hood
- @nisarhassan12 and me paired on this. We had to exchange some of the provided styles, to make the UI fit for our needs. This means, we extracted the corresponding fields and put them to the `assets`. When having the corresponding files in the `assets` we have no need to install the package itself, because nothing get imported from there.
- I added the imports to it like mentioned in the docs, within the `app.html`. This could be moved to a `svelte:head` Tag. By doing so, I had the issue that the app couldn't find the file then and threw an error though. The import references the files from the `assets`
- The Package doesn' t provide event-hooks. This means that we would need to think of another way for tracking the `screencast_started`-event.

We should review this, once you are back from your vacation @mikenikles 
<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

