### PR TITLE
Tbarber/access env vars prebuild

### DIFF
--- a/gitpod/docs/prebuilds.md
+++ b/gitpod/docs/prebuilds.md
@@ -188,12 +188,9 @@ github:
 The `addComment` and `addBadge` behaviours are not mutually exclusive (i.e. enabling one does not disable the other).
 If you don't want the comments to be added, disable them using `addComment: false`.
 
-## Access to environment variables
+## Access to environment variables in Prebuilds
 
-It is not necesarily best practice to have user specific environment variables in a prebuild init block, but sometimes
-there are build time requirements that mean certain tokens need setting or files need creating. Environment variables
-defined within your Variable preferences are no imported by default but they can be accessed with the following command
-within an init block:
+It is not necessarily best practice to have user specific environment variables in a prebuild `init` block, but sometimes there are build time requirements that mean certain tokens need setting or files need creating. Environment variables defined within your Gitpod Variables preferences are not imported by default, but they can be accessed with the following command within an `init` block:
 
 ```yaml
 tasks:
@@ -201,5 +198,4 @@ tasks:
       eval $(gp env -e)
 ```
 
-at which point the available environment variables will be installed into the rest of you shell script and can be
-accessed normally.
+After that, the available environment variables will be installed into the rest of you shell script and can be accessed normally.

--- a/gitpod/docs/prebuilds.md
+++ b/gitpod/docs/prebuilds.md
@@ -187,3 +187,18 @@ github:
 
 The `addComment` and `addBadge` behaviours are not mutually exclusive (i.e. enabling one does not disable the other).
 If you don't want the comments to be added, disable them using `addComment: false`.
+
+## Access to environment variables
+
+It is not necesarily best practice to have user specific environment variables in a prebuild init block, but sometimes
+there are build time requirements that mean certain tokens need setting or files need creating. Environment variables
+defined within your Variable preferences are no imported by default but they can be accessed with the following command
+within an init block:
+
+```yaml
+tasks:
+  - init: |
+      eval $(gp env -e)
+```
+
+at which point the available environment variables will be installed into the rest of you shell script.

--- a/gitpod/docs/prebuilds.md
+++ b/gitpod/docs/prebuilds.md
@@ -201,4 +201,5 @@ tasks:
       eval $(gp env -e)
 ```
 
-at which point the available environment variables will be installed into the rest of you shell script.
+at which point the available environment variables will be installed into the rest of you shell script and can be
+accessed normally.


### PR DESCRIPTION
## Description

Add small block about accessing environment variables from prebuild init blocks as discussed on Discord.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1429"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

