### PR TITLE
create generic reusable button components. 

### DIFF
--- a/src/lib/components/button/base.svelte
+++ b/src/lib/components/button/base.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { Button } from "$lib/types/button.type";
+
+  let clazz = "";
+  export { clazz as class };
+  export let button: Button;
+
+  const { href, text } = button;
+  const target = href ? "_blank" : undefined;
+</script>
+
+<a
+  {href}
+  {target}
+  class="inline-block text-center font-semibold py-macro px-xx-small rounded-xl shadow-light text-btn-small leading-4 text-black {clazz}"
+>
+  {text}
+</a>

--- a/src/lib/components/button/button-cta.svelte
+++ b/src/lib/components/button/button-cta.svelte
@@ -1,0 +1,2 @@
+<script>
+</script>

--- a/src/lib/types/button.type.ts
+++ b/src/lib/types/button.type.ts
@@ -1,0 +1,5 @@
+export type Button = {
+  as?: "link" | "button";
+  href?: string;
+  text?: string;
+};


### PR DESCRIPTION
Fixes #1433 

This can be used as an inspiration https://github.com/matyunya/smelte/blob/master/src/components/Button/Button.svelte

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1477"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

