### PR TITLE
docs(prebuilds): clarify example about user variables

### DIFF
--- a/gitpod/docs/prebuilds.md
+++ b/gitpod/docs/prebuilds.md
@@ -209,12 +209,16 @@ If you don't want the comments to be added, disable them using `addComment: fals
 
 ## User specific environment variables in prebuilds
 
-It is not necessarily best practice to have user specific environment variables in a prebuild `init` block, but sometimes there are build time requirements that mean certain tokens need setting or files need creating. Environment variables defined within your Gitpod Variables preferences are not imported by default, but they can be accessed with the following command within an `init` block:
+It is not necessarily best practice to have user specific environment variables in a prebuild `before` or `init` block, but sometimes there are build time requirements that mean certain tokens need setting or files need creating. Environment variables defined within your Gitpod Variables preferences are not imported by default, but they can be accessed with the following command within a `before` or `init` block:
 
 ```yaml
 tasks:
+  - before: |
+      eval $(command gp env -e)
+      echo "Hello ${MY_VAR}"
   - init: |
-      eval $(gp env -e)
+      eval $(command gp env -e)
+      echo "Hello ${MY_VAR}"
 ```
 
 After that, the available environment variables will be installed into the rest of you shell script and can be accessed normally.


### PR DESCRIPTION
## Description
I wasn't sure if user specific environment variables were available in `before` scripts (which are the suggested scripts where to globally install npm packages from), so I did my tests and found out.

I also found out that `gp` is an alias for `git pull` in the `git` plugin for `oh-my-zsh` so I had to specify the full path.
Given how popular `oh-my-zsh` is, and that the `git` plugin is enabled by default, I thought it'd be safer to also propose this change to the provided example.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
updated example on how to use user specific environment variables in prebuilds
```

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1526"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1526"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

