### PR TITLE
Update self-hosted docs for helm deprecation

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -64,6 +64,7 @@
 /docs/ruby-in-gitpod /docs/languages/ruby 301
 /docs/rust-in-gitpod /docs/languages/rust 301
 /docs/self-hosted/latest/self-hosted /docs/self-hosted/latest 301
+/docs/self-hosted/latest/installation/on-kubernetes /docs/self-hosted/latest/installation 301
 /docs/vue-in-gitpod /docs/languages/vue 301
 /docs/editors/jetbrains-private-beta /docs/editors/ 301
 /education /pricing#do-you-offer-discounts-for-students-and-educational-institutions 301

--- a/gitpod/docs/self-hosted/latest/configuration/authentication.md
+++ b/gitpod/docs/self-hosted/latest/configuration/authentication.md
@@ -9,6 +9,10 @@ title: Configure the authentication used by your Gitpod Self-Hosted installation
 
 # Configure the authentication used by your Gitpod Self-Hosted installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Gitpod does not implement user authentication itself, but integrates with other auth provider using [OAuth2](https://oauth.net/2/).
 Usually your Git hosting solution (e.g. GitHub or GitLab) acts as the OAuth auth provider. This way we control access to Gitpod while at
 the same time making sure every user has proper access to their Git repository.

--- a/gitpod/docs/self-hosted/latest/configuration/database.md
+++ b/gitpod/docs/self-hosted/latest/configuration/database.md
@@ -9,6 +9,10 @@ title: Configure the database used by your Gitpod installation
 
 # Configure the database used by your Gitpod installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in. If you operate your own MySQL database (which we'd recommend in a production setting) you can use that one. You have the following options:
 
 - Integrated database: If not disabled, this MySQL database is installed in a Kubernetes pod as a part of Gitpod’s Helm chart.

--- a/gitpod/docs/self-hosted/latest/configuration/docker-registry.md
+++ b/gitpod/docs/self-hosted/latest/configuration/docker-registry.md
@@ -9,6 +9,10 @@ title: Configure the Docker registry used by your Gitpod Self-Hosted installatio
 
 # Configure the Docker registry used by your Gitpod Self-Hosted installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Gitpod builds Docker images during workspace startup. This enables custom Dockerfiles as part of your workspace config, but is also required for Gitpod itself to function.
 To this end, Gitpod requires a container registry where it can push the images it builds.
 

--- a/gitpod/docs/self-hosted/latest/configuration/index.md
+++ b/gitpod/docs/self-hosted/latest/configuration/index.md
@@ -9,6 +9,10 @@ title: Configuring Gitpod Self-Hosted
 
 # Configuring Gitpod Self-Hosted
 
+> ⚠️ **Deprecated Content**
+>
+> The content of the linked pages assume you are using Helm, which is now deprecated.
+
 - [Configure the database used by your Gitpod Self-Hosted installation](./configuration/database)
 - [Configure the Docker registry used by your Gitpod Self-Hosted installation](./configuration/docker-registry)
 - [Configure the ingress to your Gitpod Self-Hosted installation](./configuration/ingress)

--- a/gitpod/docs/self-hosted/latest/configuration/ingress.md
+++ b/gitpod/docs/self-hosted/latest/configuration/ingress.md
@@ -9,6 +9,10 @@ title: Configure the ingress to your Gitpod installation
 
 # Configure the ingress to your Gitpod installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Configuring ingress into your Gitpod installation requires two things:
 
 - three DNS entries pointing at the IP of Gitpod's proxy service, and

--- a/gitpod/docs/self-hosted/latest/configuration/nodes.md
+++ b/gitpod/docs/self-hosted/latest/configuration/nodes.md
@@ -9,6 +9,10 @@ title: Configure the Kubernetes nodes in your Gitpod Self-Hosted installation
 
 # Configure the Kubernetes nodes in your Gitpod Self-Hosted installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Configure the nodes (computers or virtual machines) that Kubernetes runs Gitpod's workspace pods on.
 
 ## Assign workload to Nodes

--- a/gitpod/docs/self-hosted/latest/configuration/storage.md
+++ b/gitpod/docs/self-hosted/latest/configuration/storage.md
@@ -9,6 +9,10 @@ title: Configure the storage used by your Gitpod installation
 
 # Configure the storage used by your Gitpod installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Gitpod uses bucket storage to persist the contents of workspaces. Each workspace is tarballed into a single archive file which is then uploaded to a separate bucket.
 
 By default Gitpod installs [MinIO](https://min.io/) as built-in bucket storage which uses a [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to store workspace content.

--- a/gitpod/docs/self-hosted/latest/configuration/vsx-registry.md
+++ b/gitpod/docs/self-hosted/latest/configuration/vsx-registry.md
@@ -9,6 +9,10 @@ title: Configure the VSX registry used by your Gitpod Self-Hosted installation
 
 # Configure the VSX registry used by your Gitpod Self-Hosted installation
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 Gitpod uses the public [OpenVSX](https://open-vsx.org) registry as only products produced by Microsoft may access the Visual Studio Code Marketplace. This document explains how Gitpod Self-Hosted can be configured in air-gapped scenarios to connect to a private OpenVSX registry.
 
 ## Configuration

--- a/gitpod/docs/self-hosted/latest/configuration/workspaces.md
+++ b/gitpod/docs/self-hosted/latest/configuration/workspaces.md
@@ -9,6 +9,10 @@ title: Configure the Gitpod Workspaces in your Gitpod Self-Hosted installation
 
 # Workspaces
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 ## Sizing
 
 Gitpod schedules workspaces as Kubernetes pods. Each workspace pod requests a certain amount of memory which directly affects how many workspaces are scheduled on a single node.

--- a/gitpod/docs/self-hosted/latest/index.md
+++ b/gitpod/docs/self-hosted/latest/index.md
@@ -9,12 +9,21 @@ title: Gitpod Self-Hosted
 
 # Gitpod Self-Hosted
 
-Gitpod, just as you know it from [gitpod.io](https://gitpod.io), can be deployed and operated on your own infrastructure. It supports different cloud providers, self-managed Kubernetes clusters, corporate firewalls, and even off-grid / air-gapped networks.
+Gitpod can be deployed and operated on your own infrastructure. It supports different cloud providers, self-managed Kubernetes clusters, corporate firewalls, and even off-grid / air-gapped networks.
 
-- [Requirements for Gitpod Self-Hosted](./latest/requirements)
-- [Installing Gitpod Self-Hosted](./latest/installation)
-- [Configuring Gitpod Self-Hosted](./latest/configuration)
-- [Administrating Gitpod Self-Hosted](./latest/administration)
-- [Troubleshooting Gitpod Self-Hosted](./latest/troubleshooting)
-- [Updating Gitpod Self-Hosted](./latest/updating)
-- [Gitpod Self-Hosted releases](./latest/releases)
+### Getting Started
+
+1. [Requirements](./latest/requirements)
+2. [Installation](./latest/installation)
+3. [Configuration](./latest/configuration)
+
+If at any time you face any issues, check our [Troubleshooting](./latest/troubleshooting) page.
+
+### Operating Gitpod Self-Hosted
+
+- [Administration](./latest/administration)
+- [Updating](./latest/updating)
+
+### Reference
+
+- [Releases](./latest/releases)

--- a/gitpod/docs/self-hosted/latest/installation/helm-on-kubernetes.md
+++ b/gitpod/docs/self-hosted/latest/installation/helm-on-kubernetes.md
@@ -7,7 +7,11 @@ title: Install Gitpod Self-Hosted on Kubernetes
   export const prerender = true;
 </script>
 
-# Install Gitpod Self-Hosted on Kubernetes
+# Install Gitpod Self-Hosted on Kubernetes using Helm
+
+> ⚠️ **Deprecated**
+>
+> This guide uses the Helm installation method, which is now deprecated.
 
 This section describes how to install Gitpod on any Kubernetes cluster using [Helm](https://helm.sh). This is the most flexible and generic way of installing Gitpod. The chart for stable releases resides in Helm repository [charts.gitpod.io](https://charts.gitpod.io), charts for branch-builds can be found [here](#install-branch-build), and the source of the charts is in our [public git repository](https://github.com/gitpod-io/gitpod/blob/main/chart/).
 

--- a/gitpod/docs/self-hosted/latest/installation/index.md
+++ b/gitpod/docs/self-hosted/latest/installation/index.md
@@ -9,7 +9,30 @@ title: Installing Gitpod Self-Hosted
 
 # Install Gitpod Self-Hosted
 
-- [Install Gitpod Self-Hosted on Amazon Elastic Kubernetes Service (EKS)](./installation/on-amazon-eks)
-- [Install Gitpod Self-Hosted on Google Kubernetes Engine (GKE)](./installation/on-gke)
-- [Install Gitpod Self-Hosted on Kubernetes](./installation/on-kubernetes)
-- [Install Gitpod Self-Hosted on Microsoft Azure Kubernetes Service (AKS)](./installation/on-microsoft-aks)
+There are two supported methods of installing Gitpod Self-Hosted:
+
+- [Replicated](#using-replicated) — the easiest and commercially supported
+- [Installer](#using-the-installer) — the most flexible
+
+Using [Helm](#using-helm-deprecated) is now deprecated.
+
+## Using Replicated
+
+> 👀 **Coming Soon**
+>
+> We are working on this installation method and will update this page very soon.
+
+## Using the Installer
+
+> 🚧 **Under Construction**
+>
+> You may find a preliminary version of this section [here](https://github.com/gitpod-io/gitpod/blob/main/installer/README.md#quickstart).
+
+## Using Helm (deprecated)
+
+Historically, Helm was used to install Gitpod Self-Hosted. This method is now deprecated but you may still find them here:
+
+- [Amazon Elastic Kubernetes Service (EKS)](./installation/on-amazon-eks)
+- [Google Kubernetes Engine (GKE)](./installation/on-gke)
+- [Microsoft Azure Kubernetes Service (AKS)](./installation/on-microsoft-aks)
+- [Kubernetes](./installation/helm-on-kubernetes)

--- a/gitpod/docs/self-hosted/latest/installation/on-amazon-eks.md
+++ b/gitpod/docs/self-hosted/latest/installation/on-amazon-eks.md
@@ -9,6 +9,10 @@ title: Install Gitpod Self-Hosted on Amazon Elastic Kubernetes Service (EKS)
 
 # Install Gitpod Self-Hosted on Amazon Elastic Kubernetes Service (EKS)
 
+> ⚠️ **Deprecated Contents**
+>
+> This guide uses the Helm installation method, which is now deprecated. We will update it soon.
+
 Installation instructions for Gitpod Self-Hosted on Amazon EKS are currently located in the [gitpod-io/gitpod-eks-guide](https://github.com/gitpod-io/gitpod-eks-guide) repository on GitHub. The installation process takes around forty minutes. In the end, the following resources are created:
 
 - An Amazon EKS cluster running Kubernetes v1.20

--- a/gitpod/docs/self-hosted/latest/installation/on-gke.md
+++ b/gitpod/docs/self-hosted/latest/installation/on-gke.md
@@ -9,6 +9,10 @@ title: Install Gitpod Self-Hosted on Google Kubernetes Engine (GKE)
 
 # Install Gitpod Self-Hosted on Google Kubernetes Engine (GKE)
 
+> ⚠️ **Deprecated Contents**
+>
+> This guide uses the Helm installation method, which is now deprecated. We will update it soon.
+
 Installation instructions for Gitpod Self-Hosted on Google Kubernetes Engine are currently located in the [gitpod-io/gitpod-gke-guide](https://github.com/gitpod-io/gitpod-gke-guide) repository on GitHub. The installation process takes around twenty minutes. In the end, the following resources are created:
 
 - A GKE cluster running Kubernetes v1.21 ([rapid channel](https://cloud.google.com/kubernetes-engine/docs/release-notes-rapid)).

--- a/gitpod/docs/self-hosted/latest/requirements/index.md
+++ b/gitpod/docs/self-hosted/latest/requirements/index.md
@@ -15,7 +15,7 @@ This page details the software and hardware requirements for installing Gitpod S
 
 Gitpod Self-Hosted runs well on:
 
-- Amazon Elastic Kubernetes Service]
+- Amazon Elastic Kubernetes Service
 - Google Kubernetes Engine
 - Microsoft Azure Kubernetes Service
 - K3s

--- a/gitpod/docs/self-hosted/latest/requirements/index.md
+++ b/gitpod/docs/self-hosted/latest/requirements/index.md
@@ -15,10 +15,10 @@ This page details the software and hardware requirements for installing Gitpod S
 
 Gitpod Self-Hosted runs well on:
 
-- [Amazon Elastic Kubernetes Service](./installation/on-amazon-eks)
-- [Google Kubernetes Engine](./installation/on-gke)
-- [K3s](./installation/on-kubernetes)
-- [Microsoft Azure Kubernetes Service](./installation/on-microsoft-aks)
+- Amazon Elastic Kubernetes Service]
+- Google Kubernetes Engine
+- Microsoft Azure Kubernetes Service
+- K3s
 
 ## Incompatible Kubernetes distributions
 

--- a/gitpod/docs/self-hosted/latest/troubleshooting/index.md
+++ b/gitpod/docs/self-hosted/latest/troubleshooting/index.md
@@ -9,6 +9,10 @@ title: Troubleshooting Gitpod Self-Hosted
 
 # Troubleshooting Gitpod Self-Hosted
 
+> ⚠️ **Deprecated Content**
+>
+> The content of this page assumes you are using Helm, which is now deprecated.
+
 This section should solve all errors that might come up during installation of Gitpod.
 
 ## 1. `ws-daemon` is stuck in `Init: 0/1`

--- a/src/lib/components/self-hosted/view-all-features.svelte
+++ b/src/lib/components/self-hosted/view-all-features.svelte
@@ -48,11 +48,7 @@
 
 <SectionCommon
   title="View all features"
-  text="Install Gitpod Self-hosted on
-	  <a href='/docs/self-hosted/latest/installation/on-gke'>GKE</a>,
-	  <a href='/docs/self-hosted/latest/installation/on-amazon-eks'>EKS</a>,
-	  <a href='/docs/self-hosted/latest/installation/on-microsoft-aks'>AKS</a> or
-	  <a href='/docs/self-hosted/latest/installation/on-kubernetes'>K3s</a>."
+  text="Install Gitpod Self-hosted on GKE, EKS, AKS, or K3s."
   textClassNames="mb-xx-small"
 >
   <div class="featureTable" slot="content">

--- a/src/lib/contents/self-hosted.ts
+++ b/src/lib/contents/self-hosted.ts
@@ -204,12 +204,12 @@ export const selfhostedFAQ: FAQ = {
     {
       title: "How can I install Self-Hosted?",
       content:
-        ' <p> You can either install <strong>Gitpod Self-Hosted</strong> on <a href="/docs/self-hosted/latest/installation/on-gke">Google GKE</a>, <a href="/docs/self-hosted/latest/installation/on-amazon-eks" >Amazon EKS</a >, <a href="/docs/self-hosted/latest/installation/on-microsoft-aks" >Azure AKS</a > or <a href="/docs/self-hosted/latest/installation/on-kubernetes">K3s</a>. See <a href="/docs/self-hosted/latest">Self-Hosted Docs</a> for more information. </p>',
+        '<p> You can either install <strong>Gitpod Self-Hosted</strong> on Google GKE, Amazon EKS, Azure AKS, or K3s. See <a href="/docs/self-hosted/latest">Self-Hosted Docs</a> for more information. </p>',
     },
     {
       title: "How can I pay?",
       content:
-        ' <p> Currently, <strong>Gitpod Self-Hosted</strong> can only be purchased on request. Please <a href="/enterprise-license">request a license key</a> and we\'ll contact you. If you have any questions, please <a href="/contact/sales">Get in touch</a>. All our plans can be paid via invoice. </p>',
+        '<p> Currently, <strong>Gitpod Self-Hosted</strong> can only be purchased on request. Please <a href="/enterprise-license">request a license key</a> and we\'ll contact you. If you have any questions, please <a href="/contact/sales">Get in touch</a>. All our plans can be paid via invoice. </p>',
     },
     {
       title: "Do you offer discounts for educational institutions?",

--- a/src/routes/self-hosted.svelte
+++ b/src/routes/self-hosted.svelte
@@ -24,11 +24,7 @@
   contents={{
     title: "Install <div class='whitespace-nowrap inline'>Self-hosted</div>",
     description: `
-      Install Gitpod Self-hosted on
-        <a href='/docs/self-hosted/latest/installation/on-gke'>GKE</a>,
-        <a href='/docs/self-hosted/latest/installation/on-amazon-eks'>EKS</a>,
-        <a href='/docs/self-hosted/latest/installation/on-microsoft-aks'>AKS</a> or
-        <a href='/docs/self-hosted/latest/installation/on-kubernetes'>K3s</a>.
+      Install Gitpod Self-hosted on GKE, EKS, AKS, or K3s.
     `,
     link: { href: "/docs/self-hosted/latest", text: "View installation guide" },
   }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update self-hosted docs to make clear that Helm is now deprecated, and the new Installer or Replicated should be used. Without affecting SEO.

[Related PR](https://github.com/gitpod-io/website/pull/1441)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
```release-note
NONE
```


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1536"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1536"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

