### PR TITLE
Allow `*.staging.gitpod-dev.com` as a `frame-ancestor`

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -64,7 +64,7 @@ const handleHeaders = async ({ event, resolve }) => {
   // Avoid clickjacking attacks, see https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html
   response.headers.set(
     "Content-Security-Policy",
-    "frame-ancestors *.gitpod.io;"
+    "frame-ancestors *.gitpod.io *.staging.gitpod-dev.com;"
   );
   return response;
 };


### PR DESCRIPTION
FIxes #1553

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1554"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

