### PR TITLE
Pricing: display all 4 pricing cards in one row for standard device

### DIFF
--- a/src/lib/components/pricing/pricing-box.svelte
+++ b/src/lib/components/pricing/pricing-box.svelte
@@ -61,7 +61,7 @@
 </style>
 
 <div
-  class={`box flex flex-col justify-between items-center bg-gray-100 pt-small px-0 mt-0 mx-micro mb-x-small rounded-2xl shadow-normal text-center transition-all duration-200 hover:shadow-brand ${
+  class={`box flex flex-col justify-between items-center bg-gray-100 pt-small px-0 mt-0 mx-macro 2xl:mx-micro mb-x-small rounded-2xl shadow-normal text-center transition-all duration-200 hover:shadow-brand ${
     spiced ? "spiced shadow-brand" : ""
   }`}
 >

--- a/src/lib/components/pricing/pricing-boxes.svelte
+++ b/src/lib/components/pricing/pricing-boxes.svelte
@@ -6,6 +6,7 @@
 </script>
 
 <style lang="postcss">
+  /* ! do not remove the following block with the custom random breakpoint value 1250px as it addresses https://github.com/gitpod-io/website/issues/1505  */
   div {
     @media (max-width: 1250px) {
       @apply flex-wrap;

--- a/src/lib/components/pricing/pricing-boxes.svelte
+++ b/src/lib/components/pricing/pricing-boxes.svelte
@@ -5,7 +5,15 @@
   export let pricingPlans: Pricing[];
 </script>
 
-<div class="flex flex-wrap justify-center">
+<style lang="postcss">
+  div {
+    @media (max-width: 1250px) {
+      @apply flex-wrap;
+    }
+  }
+</style>
+
+<div class="flex justify-center">
   {#each pricingPlans as pricing}
     <PricingBox {pricing} />
   {/each}


### PR DESCRIPTION
This is how they look on a 13" Macbook Pro:

![image](https://user-images.githubusercontent.com/46004116/151727152-9a084df0-656b-410a-8d33-e29fd6a5e500.png)


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1557"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

