### PR TITLE
Fix 404 link to Workspace-Full Dockerfile

### DIFF
--- a/gitpod/docs/config-docker.md
+++ b/gitpod/docs/config-docker.md
@@ -9,7 +9,7 @@ title: Custom Docker Image
 
 # Custom Docker Image
 
-By default, Gitpod uses a standard Docker Image called [`Workspace-Full`](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile) as the foundation for workspaces. Workspaces started based on this default image come pre-installed with Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as tools such as Homebrew, Tailscale, Nginx and several more.
+By default, Gitpod uses a standard Docker Image called [`Workspace-Full`](https://github.com/gitpod-io/workspace-images/blob/master/legacy/full/Dockerfile) as the foundation for workspaces. Workspaces started based on this default image come pre-installed with Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as tools such as Homebrew, Tailscale, Nginx and several more.
 
 If this image does not include the tools you need for your project, you can provide a public Docker image or your own [Dockerfile](#using-a-dockerfile). This provides you with the flexibility to install the tools & libraries required for your project.
 
@@ -45,7 +45,7 @@ image:
 Next, create a `.gitpod.Dockerfile` file at the root of your project. The syntax is the regular `Dockerfile` syntax as <a href="https://docs.docker.com/engine/reference/builder/" target="_blank">documented on docs.docker.com</a>.
 
 A good starting point for creating a custom `.gitpod.Dockerfile` is the
-<a href="https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile" target="_blank">gitpod/workspace-full</a> image as it already contains all the tools necessary to work with all languages Gitpod supports.
+<a href="https://github.com/gitpod-io/workspace-images/blob/master/legacy/full/Dockerfile" target="_blank">gitpod/workspace-full</a> image as it already contains all the tools necessary to work with all languages Gitpod supports.
 
 ```dockerfile
 FROM gitpod/workspace-full

--- a/src/routes/blog/gitpod-launch.md
+++ b/src/routes/blog/gitpod-launch.md
@@ -31,7 +31,7 @@ You can try Gitpod right now. It's free for public repositories.
 
 ## No Setup
 
-Not all projects are equal. We maintain a [developer friendly Docker image](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile) that includes all the commonly used tools and version managers. But you can point to your own Docker image in a **.gitpod.yml** file. Gitpod will pick it up and even build the image if needed. Read [Gero's post](/blog/docker-in-gitpod) for more details.
+Not all projects are equal. We maintain a [developer friendly Docker image](https://github.com/gitpod-io/workspace-images/blob/master/legacy/full/Dockerfile) that includes all the commonly used tools and version managers. But you can point to your own Docker image in a **.gitpod.yml** file. Gitpod will pick it up and even build the image if needed. Read [Gero's post](/blog/docker-in-gitpod) for more details.
 
 With Gitpod, contributors don’t need to go through a list of usually outdated setup instructions. Instead, they get exactly what they need for the project at hand with no additional effort. As a side-effect, any "works-on-my-machine" scenarios are eliminated, because every team member uses the same working setup on the same kind of machine in the cloud. Since the **.gitpod.yml** is versioned with the code, going back to old releases and branches becomes super easy, too. We call this [dev environment as code](/blog/dev-env-as-code).
 

--- a/src/routes/blog/gitpodify.md
+++ b/src/routes/blog/gitpodify.md
@@ -151,7 +151,7 @@ To see all configuration options for the Gitpod app, please visit [the docs](/do
 
 ## Installing missing packages
 
-The default Docker image for all Gitpod workspaces ([gitpod/workspace-full](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile)) already comes with many common developer tools. But sometimes you may see an error like this one:
+The default Docker image for all Gitpod workspaces ([gitpod/workspace-full](https://github.com/gitpod-io/workspace-images/blob/master/legacy/full/Dockerfile)) already comes with many common developer tools. But sometimes you may see an error like this one:
 
 > `bash: tool: command not found`
 

--- a/src/routes/blog/root-docker-and-vscode.md
+++ b/src/routes/blog/root-docker-and-vscode.md
@@ -31,7 +31,7 @@ After investigating different options such as [gVisor](https://github.com/google
 
 ## Docker 🐳
 
-With the new privileges you can now also run and build Docker images to start containers within your workspace. Gitpod’s default image ([workspace-full](https://github.com/gitpod-io/workspace-images/blob/master/full/Dockerfile)) comes equipped with Docker now, so all you need to do is run `sudo docker-up` and wait until the service is listening. Now start another terminal and use the Docker CLI as usual. Here is a short screencast showing how to start a simple hello world example.
+With the new privileges you can now also run and build Docker images to start containers within your workspace. Gitpod’s default image ([workspace-full](https://github.com/gitpod-io/workspace-images/blob/master/legacy/full/Dockerfile)) comes equipped with Docker now, so all you need to do is run `sudo docker-up` and wait until the service is listening. Now start another terminal and use the Docker CLI as usual. Here is a short screencast showing how to start a simple hello world example.
 
 `youtube: tW9zBHH37Cc`
 


### PR DESCRIPTION
## Description
The link to the `Workspace-Full` Dockerfile currently returns a 404.  This links to the legacy file to make sure folks can find it as an example image.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1563"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

