### PR TITLE
Remove link to private repository

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,7 +1,6 @@
 /blog/gitlab-integration/+ /blog/gitlab-integration 301
 /careers https://gitpod.crew.work/jobs 301
 /chat https://discord.com/invite/gitpod 301
-/cla https://www.github.com/gitpod-io/cla
 /code-of-conduct https://github.com/gitpod-io/.github/blob/main/CODE_OF_CONDUCT.md
 /configure/editor /docs/editors/vscode 301
 /direction https://www.notion.so/gitpod/Gitpod-s-Direction-be35d064c0704fbda61c542b84e07ef6 301

--- a/gitpod/docs/contribute/features-and-patches/index.md
+++ b/gitpod/docs/contribute/features-and-patches/index.md
@@ -13,7 +13,6 @@ Gitpod is developed as an open core product under an [OSI-approved open source l
 
 Gitpodders have built-in the open for the last decade. Transparency is key and as a company Gitpod strives to be as open about as many things as possible. This refers to both developing Gitpod in the open (public issues, public roadmap, public milestones) as well as how employees interact on a personal level with other human beings. Gitpodders are strong believers in the benefits that an open culture provides. At Gitpod we are open-minded, inclusive, transparent, and curious. We always remain students of the game, not masters of the game.
 
-- [Contributor license agreement](https://www.gitpod.io/cla)
 - [Code Style](features-and-patches/code-style)
 - [Commit message convention](features-and-patches/commit-message-convention)
 - [Submitting a pull request](features-and-patches/submitting-a-pull-request)

--- a/gitpod/docs/contribute/features-and-patches/submitting-a-pull-request.md
+++ b/gitpod/docs/contribute/features-and-patches/submitting-a-pull-request.md
@@ -41,8 +41,6 @@ git push origin my-fix-branch
 
 In GitHub, send a pull request to `gitpod-io:main`.
 
-- Sign the [Contributor License Agrement](https://www.gitpod.io/cla) if prompted by the robots.
-
 If we suggest changes, then:
 
 - Make the required updates.
@@ -58,8 +56,6 @@ Before you submit your pull request, please:
 
 - If you are considering submitting a pull-request that is more than a simple fix, open a discussion on GitHub first with your proposal.
 - Search [GitHub](https://github.com/gitpod-io/gitpod/pulls) for an open or closed Pull Request that relates to your submission.
-
-- Sign the [Contributor License Agrement](https://www.gitpod.io/cla) if prompted by the robots.
 
 If we suggest changes, then:
 


### PR DESCRIPTION
## Description

Temporarily remove a link to a private repository since this has cause confusion more than a couple of times already. For example, see https://github.com/gitpod-io/gitpod/issues/7864  and https://github.com/gitpod-io/gitpod/pull/8813#issuecomment-1072420711.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1789"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

