### PR TITLE
Add export log section in troubleshooting

### DIFF
--- a/gitpod/docs/troubleshooting.md
+++ b/gitpod/docs/troubleshooting.md
@@ -11,6 +11,14 @@ title: Troubleshooting
 
 If you cannot find your issue here or in the documentation, please contact Gitpod via our [Support page](/support).
 
+## Gitpod logs in VSCode Web
+
+These logs contain information about the workspace, the session, and the Visual Studio Code environment. They are useful for diagnosing connection issues and other unexpected behavior.
+
+- Open the Visual Studio Code Command Palette (`Shift + Command + P` (Mac) / `Ctrl + Shift + P` (Windows)) and type **Export logs**, select **Developer: Export all logs** from the list to download a zip file containing all the logs.
+
+**Important:** The content of these logs should NOT be shared publicly as it could containt sensitive information from your workspace, instead send it to support@gitpod.io along with a link to a corresponding Github issue if needed.
+
 ## Why doesn't the "ClearURLs" browser extension work with Gitpod?
 
 The ClearURLs browser extension for [Google Chrome](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk?hl=en) and [Mozilla Firefox](https://addons.mozilla.org/en-US/firefox/addon/clearurls/) inhibits Gitpod workspaces from initialising and the problem manifests with the following symptoms:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add export log section in troubleshooting

Related https://github.com/gitpod-io/openvscode-server/pull/327

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1853"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

