### PR TITLE
[Analytics] Remove redundant `product_cta_clicked` track call

### DIFF
--- a/src/lib/components/jetbrains-space/hero.svelte
+++ b/src/lib/components/jetbrains-space/hero.svelte
@@ -37,12 +37,7 @@
       class="mt-x-small"
       variant="primary"
       size="large"
-      href="https://gitpod.io/workspaces/"
-      on:click={() =>
-        window.analytics.track("product_cta_clicked", {
-          context: "hero",
-          destination: "https://gitpod.io/workspaces/",
-        })}>Try Now</LinkButton
+      href="https://gitpod.io/workspaces/">Try Now</LinkButton
     >
   </div>
   <img

--- a/src/routes/vs/jetbrains-space.svelte
+++ b/src/routes/vs/jetbrains-space.svelte
@@ -32,11 +32,6 @@
   btnPrimary={{
     href: "https://gitpod.io/workspaces/",
     text: "Try Now",
-    onClickHandler: () =>
-      window.analytics.track("product_cta_clicked", {
-        context: "hero",
-        destination: "https://gitpod.io/workspaces/",
-      }),
   }}
 />
 


### PR DESCRIPTION
Removes `product_cta_clicked` track call. The call is made redundant through `website_clicked`, which contains information about which button was clickced in the properties.

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/1855"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

