### PR TITLE
Update config-ports.md

### DIFF
--- a/gitpod/docs/config-ports.md
+++ b/gitpod/docs/config-ports.md
@@ -9,7 +9,7 @@ title: Configure Ports
 
 # Configure Ports
 
-When your project starts a service that listens on a given port, Gitpod automatically serves traffic to this port to your on an authenticated URL.
+When your project starts a service that listens on a given port, Gitpod automatically serves traffic to this port to your application on an authenticated URL.
 
 If you want to configure ports, such as their visibility, what Gitpod does when it detects a new port being available, etc, you do that in the `ports` section of the [`.gitpod.yml`](/docs/references/gitpod-yml) configuration file.
 


### PR DESCRIPTION
Missing words

## Description
There seems to be a missing word in the sentence `Gitpod automatically serves traffic to this port to your <?> on an authenticated URL.`. But I am not exactly sure what should go here, application? service? 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1866"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

