### PR TITLE
[Draft] Add ability to have section headers in submenus on docs page

### DIFF
--- a/src/lib/components/docs/menu-section.svelte
+++ b/src/lib/components/docs/menu-section.svelte
@@ -36,7 +36,11 @@
             class="flex flex-row items-center"
             data-analytics={`{"context":"submenu"}`}
           >
-            <MenuLink href={sub.path}>{sub.title}</MenuLink>
+            {#if !sub.isSubeMenuCategoryHeader}
+              <MenuLink href={sub.path}>{sub.title}</MenuLink>
+            {:else}
+              <div class="text-p-medium"><b>{sub.title}</b></div>
+            {/if}
             {#if sub.status}
               <Pill
                 text={sub.status}

--- a/src/lib/components/docs/mobile-menu/sub-menu.svelte
+++ b/src/lib/components/docs/mobile-menu/sub-menu.svelte
@@ -103,16 +103,25 @@
     >
       <ul class="divide-y divide-sand-dark">
         {#each currentSection?.subMenu as sub}
-          <MenuItem href={sub.path} onClick={() => ($subMenuState = false)}>
-            {sub.title}
-            {#if sub.status}
-              <Pill
-                variant={sub.status === "soon" ? "pink" : "orange"}
-                text={sub.status}
-                class="ml-1.5"
-              />
-            {/if}
-          </MenuItem>
+          {#if !sub.isSubeMenuCategoryHeader}
+            <MenuItem href={sub.path} onClick={() => ($subMenuState = false)}>
+              {sub.title}
+              {#if sub.status}
+                <Pill
+                  variant={sub.status === "soon" ? "pink" : "orange"}
+                  text={sub.status}
+                  class="ml-1.5"
+                />
+              {/if}
+            </MenuItem>
+          {:else}
+            <li class="mb-0">
+              <div class="text-p-medium flex min-h-13 items-center ">
+                <b>{sub.title}</b>
+              </div>
+              <hr class="divide-sand-dark" />
+            </li>
+          {/if}
         {/each}
       </ul>
     </div>

--- a/src/lib/contents/docs/menu.ts
+++ b/src/lib/contents/docs/menu.ts
@@ -2,93 +2,97 @@ import type { MenuStatus, MenuEntry } from "$lib/types/menu-entry.type";
 
 function M(
   title: string,
+  isSubeMenuCategoryHeader: boolean,
   path: string,
   subMenu?: MenuEntry[],
   status?: MenuStatus
 ): MenuEntry {
   return {
     title,
+    isSubeMenuCategoryHeader,
     status,
-    path: "/docs" + (path ? "/" + path : ""),
+    path: path ? "/docs" + "/" + path : "",
     subMenu,
   };
 }
 
 export const MENU: MenuEntry[] = [
-  M("Introduction", ""),
-  M("Quickstart", "quickstart"),
-  M("Getting Started", "getting-started"),
-  M("Configure", "configure", [
-    M(".gitpod.yml", "config-gitpod-file"),
+  M("Introduction", false, ""),
+  M("Quickstart", false, "quickstart"),
+  M("Getting Started", false, "getting-started"),
+  M("Configure", false, "configure", [
+    M(".gitpod.yml", false, "config-gitpod-file"),
     // Why is this side bar name different to the title / URL?
-    M("Configure Docker", "config-docker"),
-    M("Start Tasks", "config-start-tasks"),
-    M("Ports", "config-ports"),
-    M("Prebuilds", "prebuilds"),
-    M("Environment Variables", "environment-variables"),
-    M("Network Bridging", "configure/tailscale"),
-    M("Workspace Location", "checkout-location"),
-    M("Browser Settings", "configure/browser-settings"),
-    M("Dotfiles", "config-dotfiles", [], "beta"),
-    M("Multi-Repo", "multi-repo-workspaces", [], "beta"),
+    M("Configure Docker", false, "config-docker"),
+    M("Start Tasks", false, "config-start-tasks"),
+    M("Ports", false, "config-ports"),
+    M("Prebuilds", false, "prebuilds"),
+    M("Environment Variables", false, "environment-variables"),
+    M("Network Bridging", false, "configure/tailscale"),
+    M("Workspace Location", false, "checkout-location"),
+    M("Browser Settings", false, "configure/browser-settings"),
+    M("Dotfiles", false, "config-dotfiles", [], "beta"),
+    M("Multi-Repo", false, "multi-repo-workspaces", [], "beta"),
   ]),
-  M("Develop", "develop", [
-    M("One workspace per task", "workspaces"),
-    M("Life of a workspace", "life-of-workspace"),
-    M("Contexts", "context-urls"),
-    M("Collaboration & Sharing", "sharing-and-collaboration"),
-    M("Teams & Projects", "teams-and-projects", [], "beta"),
-    M("Create a team plan", "teams"),
+  M("Develop", false, "develop", [
+    M("One workspace per task", false, "workspaces"),
+    M("Life of a workspace", false, "life-of-workspace"),
+    M("Contexts", false, "context-urls"),
+    M("Collaboration & Sharing", false, "sharing-and-collaboration"),
+    M("Teams & Projects", false, "teams-and-projects", [], "beta"),
+    M("Create a team plan", false, "teams"),
   ]),
-  M("IDEs & Editors", "ides-and-editors", [
-    M("VS Code Browser", "ides-and-editors/vscode-browser"),
-    M("VS Code Desktop", "ides-and-editors/vscode", [], "beta"),
-    M("IntelliJ IDEA", "ides-and-editors/intellij", [], "beta"),
-    M("GoLand", "ides-and-editors/goland", [], "beta"),
-    M("PhpStorm", "ides-and-editors/phpstorm", [], "beta"),
-    M("PyCharm", "ides-and-editors/pycharm", [], "beta"),
-    M("CLion", "ides-and-editors/clion", [], "soon"),
-    M("DataGrip", "ides-and-editors/datagrip", [], "soon"),
-    M("Rider", "ides-and-editors/rider", [], "soon"),
-    M("RubyMine", "ides-and-editors/rubymine", [], "soon"),
-    M("WebStorm", "ides-and-editors/webstorm", [], "soon"),
-    M("Local Companion", "ides-and-editors/local-companion", [], "beta"),
-    M("JetBrains Gateway", "ides-and-editors/jetbrains-gateway", []),
-    M("VS Code Extensions", "ides-and-editors/vscode-extensions"),
-    M("Command Line (e.g. Vim)", "ides-and-editors/command-line", []),
+  M("IDEs & Editors", false, "ides-and-editors", [
+    M("VS Code Browser", false, "ides-and-editors/vscode-browser"),
+    M("VS Code Desktop", false, "ides-and-editors/vscode", [], "beta"),
+    M("IntelliJ IDEA", false, "ides-and-editors/intellij", [], "beta"),
+    M("GoLand", false, "ides-and-editors/goland", [], "beta"),
+    M("PhpStorm", false, "ides-and-editors/phpstorm", [], "beta"),
+    M("PyCharm", false, "ides-and-editors/pycharm", [], "beta"),
+    M("CLion", false, "ides-and-editors/clion", [], "soon"),
+    M("DataGrip", false, "ides-and-editors/datagrip", [], "soon"),
+    M("Rider", false, "ides-and-editors/rider", [], "soon"),
+    M("RubyMine", false, "ides-and-editors/rubymine", [], "soon"),
+    M("WebStorm", false, "ides-and-editors/webstorm", [], "soon"),
+    M("Local Companion", false, "ides-and-editors/local-companion", [], "beta"),
+    M("JetBrains Gateway", false, "ides-and-editors/jetbrains-gateway", []),
+    M("VS Code Extensions", false, "ides-and-editors/vscode-extensions"),
+    M("Command Line (e.g. Vim)", false, "ides-and-editors/command-line", []),
 
     M(
       "Configure your IDE/editor",
+      false,
       "ides-and-editors/configure-your-editor-ide",
       []
     ),
   ]),
-  M("Integrations", "integrations", [
-    M("GitLab", "gitlab-integration"),
-    M("GitHub", "github-integration"),
-    M("Bitbucket", "bitbucket-integration"),
-    M("GitHub Enterprise", "github-enterprise-integration"),
-    M("Browser Bookmarklet", "browser-bookmarklet"),
-    M("Browser Extension", "browser-extension"),
+  M("Integrations", false, "integrations", [
+    M("GitLab", false, "gitlab-integration"),
+    M("GitHub", false, "github-integration"),
+    M("Bitbucket", false, "bitbucket-integration"),
+    M("GitHub Enterprise", false, "github-enterprise-integration"),
+    M("Browser Bookmarklet", false, "browser-bookmarklet"),
+    M("Browser Extension", false, "browser-extension"),
   ]),
-  M("Gitpod Self-Hosted", "self-hosted/latest", [
-    M("Requirements", "self-hosted/latest/requirements"),
-    M("Installation", "self-hosted/latest/installation"),
-    M("Releases", "self-hosted/latest/releases"),
+  M("Gitpod Self-Hosted", false, "self-hosted/latest", [
+    M("Example Section", true, ""),
+    M("Requirements", false, "self-hosted/latest/requirements"),
+    M("Installation", false, "self-hosted/latest/installation"),
+    M("Releases", false, "self-hosted/latest/releases"),
   ]),
-  M("References", "references", [
-    M(".gitpod.yml", "references/gitpod-yml"),
-    M("Command Line Interface", "command-line-interface"),
-    // M("Custom Docker image", "references/gitpod-dockerfile"),
-    // M("Architecture", "references/architecture"),
-    M("Languages & Framework", "languages-and-frameworks"),
-    M("Roadmap", "references/roadmap"),
+  M("References", false, "references", [
+    M(".gitpod.yml", false, "references/gitpod-yml"),
+    M("Command Line Interface", false, "command-line-interface"),
+    // M("Custom Docker image",false, "references/gitpod-dockerfile"),
+    // M("Architecture",false, "references/architecture"),
+    M("Languages & Framework", false, "languages-and-frameworks"),
+    M("Roadmap", false, "references/roadmap"),
   ]),
-  M("Contribute", "contribute", [
-    M("Documentation", "contribute/documentation"),
-    M("Features & Patches", "contribute/features-and-patches"),
+  M("Contribute", false, "contribute", [
+    M("Documentation", false, "contribute/documentation"),
+    M("Features & Patches", false, "contribute/features-and-patches"),
   ]),
-  M("Troubleshooting", "troubleshooting", []),
+  M("Troubleshooting", false, "troubleshooting", []),
 ];
 
 export interface MenuContext {

--- a/src/lib/types/menu-entry.type.ts
+++ b/src/lib/types/menu-entry.type.ts
@@ -2,7 +2,8 @@ export type MenuStatus = "soon" | "beta";
 
 export type MenuEntry = {
   title: string;
-  path: string;
+  isSubeMenuCategoryHeader: boolean;
+  path?: string;
   status: MenuStatus;
   subMenu?: MenuEntry[];
 };


### PR DESCRIPTION
_This is in draft state because I am unsure if and when this will be useful. I did this to test the feasibility._ 

## Description
This is a (hacky?) way to introduce the ability to group submenu items in the docs page. In theory this should allow us provide more structure when there are a lot of Subitems, especially if there are a lot that are related to each other. 

## Current Limitations
- This needs some design love
- I'm not an engineer - hence I made it work, but I assume one can make it more elegant. I also don't know of any secondary effects this change might have on other components.

## How to test
1. Open workspace
2. Open Preview of website on port 3000
3. Navigate to Self Hosted Docs to see an Example section header within the Self Hosted Submenu

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/1930"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

