### PR TITLE
Merge Internal Compatibility Matrix with the one in the docs

### DIFF
--- a/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
+++ b/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
@@ -70,7 +70,7 @@ It is recommended to have a minimum of two node pools, grouping the `meta` and `
 
 These are the components expected on each node:
 
-- Either Ubuntu 18.04 with ≥ v5.4 kernel or Ubuntu 20.04 with ≥ v5.4 kernel
+- Either Ubuntu 18.04 with ≥ v5.4 kernel or Ubuntu 20.04 with ≥ v5.4 kernel. Other Linux distributons with said kernel should work, however we only test for Ubunutu.
 - Calico for the networking overlay and network policy
 - Containerd ≥ 1.5
 - At least 4 vCPU and 8GB of RAM

--- a/gitpod/docs/self-hosted/latest/required-components.md
+++ b/gitpod/docs/self-hosted/latest/required-components.md
@@ -9,15 +9,17 @@ title: Required Components
 
 # Required Components
 
-Gitpod relies on certain components and services for it to function. By default, most of these can be automatically installed in-cluster during installation. However, you can also configure Gitpod to use your own version of these that may or may not live inside the cluster. <!--- todo: When do we advise these to be run outside of cluster? --->
+Gitpod relies on certain components and services for it to function. By default, most of these can be automatically installed in-cluster during installation. However, you can also configure Gitpod to use your own version of these that may or may not live inside the cluster.
 
-| Component                                                                                  | Required?                     |
-| ------------------------------------------------------------------------------------------ | ----------------------------- |
-| [Bucket Storage](./required-components#bucket-storage)                                     | Use default or bring your own |
-| [Database](./required-components#database)                                                 | Use default or bring your own |
-| [Image Registry](./required-components#image-registry)                                     | Use default or bring your own |
-| [Source Control Management System](./required-components#source-control-management-system) | Use default or bring your own |
-| [Cert-manager](./required-components#cert-manager)                                         | Yes                           |
+| Component                                                                                  | Required?                     | Known Supported Versions \*                                                                                    |
+| ------------------------------------------------------------------------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Bucket Storage](./required-components#bucket-storage)                                     | Use default or bring your own | MiniIO, Google Cloud Storage, S3                                                                               |
+| [Database](./required-components#database)                                                 | Use default or bring your own | MySQL (5.7)                                                                                                    |
+| [Image Registry](./required-components#image-registry)                                     | Use default or bring your own | Docker Registry, Google Container Registry, Elastic Container Registry                                         |
+| [Source Control Management System](./required-components#source-control-management-system) | Use default or bring your own | Github.com, Gitlab.com, Bitbucket.org, Github Enterprise, Self-Managed Gitlab (14.x), Bitbucket Server (v7.20) |
+| [Cert-manager](./required-components#cert-manager)                                         | Yes                           | cert-manager v1.8                                                                                              |
+
+\* These are the component versions that we confidently support - i.e. they are part of our testing strategy. Other versions may work, however we cannot guarantee this.
 
 ## Bucket Storage
 
@@ -30,7 +32,7 @@ By default, MinIO is installed in the cluster to store static content and to bac
 
 ## Database
 
-Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in and data is stored using a Kubernetes PersistentVolume. For production settings, we recommend operating your own MySQL database (version v5.7 or newer). Which database is used can be configured during installation. <!--- todo: Is this true? How do you configure this? --->
+Gitpod uses a MySQL database to store user data. By default Gitpod ships with a MySQL database built-in and data is stored using a Kubernetes PersistentVolume. For production settings, we recommend operating your own MySQL database (version v5.7 or newer). Which database is used can be configured during installation.
 
 ## Image Registry
 


### PR DESCRIPTION
## Description
This PR aims to fold the internal Product Compatibility notion page into the existing docs structure. Structural docs improvements may follow (i.e. we may think to combine the cluster set up page and the required components page once we have reference architectures. 

Specifically, the [notion page](https://www.notion.so/gitpod/Product-Compatibility-Matrix-a7f15b2155a545aa8a7b6c27cf7e00ae) is merged in the following way:
- [Known Product Compatibility](https://www.notion.so/gitpod/b6db0a47de6e4c7092ff245c9deb7e87?v=5ad4333d65794865ad399d125e3c3698) is merged into the [required components](https://www.gitpod.io/docs/self-hosted/latest/required-components) (for the "software specific" parts and [cluster set up page](https://www.gitpod.io/docs/self-hosted/latest/cluster-set-up) (for the hardware specific parts). Do note that a lot of the content was already there.
- [Supported and unsupported k8s platforms](https://www.notion.so/gitpod/Product-Compatibility-Matrix-a7f15b2155a545aa8a7b6c27cf7e00ae#7b879fbd4e6646daa8170c835f7aef90) are covered in [cluster set up page](https://www.gitpod.io/docs/self-hosted/latest/cluster-set-up) (again, was already there before)
- [Installation methods](https://www.notion.so/gitpod/Product-Compatibility-Matrix-a7f15b2155a545aa8a7b6c27cf7e00ae#61d4b3952e1c4bc0beaaa4ac37140975) is not shown - I think this is ok, we should know which ones we support. 
- [Test installations](https://www.notion.so/gitpod/Product-Compatibility-Matrix-a7f15b2155a545aa8a7b6c27cf7e00ae#0e72c9eb5b9a420a9aaa407aac10fd6d) should be covered by the soon-to-come reference architectures.
- Add a comment in the md to point to where one needs to change something if they make changes to it 9e.g. change this in the reference architecture) and also what needs to be done (align with other teams, get everyones review on this, reach out to customer success) 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10126

## How to test
open preview, navigate to: docs>self-hosted>Required Components & Cluster Set up

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2107"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

