### PR TITLE
fix: capitalisation on command line page

### DIFF
--- a/gitpod/docs/command-line-interface.md
+++ b/gitpod/docs/command-line-interface.md
@@ -40,24 +40,24 @@ Flags:
 Use "gp [command] --help" for more information about a command.
 ```
 
-## Init
+## init
 
 Gitpod workspaces can be configured - see [Configuring Workspaces](/docs/configure) for more details. `gp init` generates a default `.gitpod.yml` file. You can customize it to match your requirements.
 
 Alternatively, `gp init -i` is an interactive guide which helps create the `.gitpod.yml` configuration file based on a few questions you answer.
 
-## Open
+## open
 
 Modern editors/IDE's support command line tooling to open a file (e.g. VS Code `code foo.txt`). In Gitpod, this can be done using `gp open <filename>`.
 We also added common aliases for `gp open`: `code` and `open`.
 
-## Preview
+## preview
 
 `gp preview` is similar to `gp open`, except that it does not open a file in the editor but a URL in a preview pane on the right.
 
 Make sure you provide a valid URL, i.e. including the protocol. For example, http://localhost:8080.
 
-## URL
+## url
 
 Gitpod workspaces can expose services to the internet. `gp url` provides the URL which points to a service served from a Gitpod workspace. For example `gp url 8080` prints the URL which points to the service listening on port 8080 in this current workspace.
 
@@ -71,7 +71,7 @@ gp preview $(gp url 3000)/my/path/index.html
 
 If you put this into the `.gitpod.yml` to open the a certain page on startup, make sure you [ignore the default action](/docs/config-ports) when the port opens.
 
-## Env
+## env
 
 With `gp env API_ENDPOINT=https://api.example.com` you can set an `API_ENDPOINT` environment variable that is accessible for this project, even if you stop the workspace and start a new one.
 
@@ -79,14 +79,14 @@ To delete or unset an environment variable, you use `gp env -u API_ENDPOINT`.
 
 Please refer to the help output provided by `gp env --help` for more use cases of the `gp env` command.
 
-## Forward Port
+## forward-port
 
 In Gitpod, services/servers running on a port need to be _exposed_ before they become accessible from the internet. This process only works with services listening on `0.0.0.0` and not just `localhost`.
 Sometimes it is not possible to make a server listen on `0.0.0.0`, e.g. because it is not your code and there are simply no means of configuration.
 
 In that case, `gp forward-port <port>` can be used to forward all traffic form a socket listing on all network interfaces to your process listening on localhost only.
 
-## Await Port
+## await-port
 
 When writing tasks to be executed on workspace start, one sometimes wants to wait for an http service to be available. `gp await-port` does that.
 


### PR DESCRIPTION
Small fix, the inconsistency was driving me wild. 

Decided to adopt lower case for all, to make it simpler for commands which are kebab-case. 

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/5528307/173348692-673b6789-44dd-4265-8df2-271ee5f5a36d.png)|![image](https://user-images.githubusercontent.com/5528307/173348635-e3be88f5-67dd-45f5-abc8-fc0330d32aa7.png)|

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2225"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

