### PR TITLE
docs: Update forward, await as ports subcommands

### DIFF
--- a/gitpod/docs/command-line-interface.md
+++ b/gitpod/docs/command-line-interface.md
@@ -18,9 +18,7 @@ Usage:
   gp [command]
 
 Available Commands:
-  await-port          Waits for a process to listen on a port
   env                 Controls user-defined, persistent environment variables.
-  forward-port        Makes a port available on 0.0.0.0 so that it can be exposed to the internet
   help                Help about any command
   init                Create a Gitpod configuration for this project.
   open                Opens a file in Gitpod
@@ -78,23 +76,6 @@ With `gp env API_ENDPOINT=https://api.example.com` you can set an `API_ENDPOINT`
 To delete or unset an environment variable, you use `gp env -u API_ENDPOINT`.
 
 Please refer to the help output provided by `gp env --help` for more use cases of the `gp env` command.
-
-## Forward Port
-
-In Gitpod, services/servers running on a port need to be _exposed_ before they become accessible from the internet. This process only works with services listening on `0.0.0.0` and not just `localhost`.
-Sometimes it is not possible to make a server listen on `0.0.0.0`, e.g. because it is not your code and there are simply no means of configuration.
-
-In that case, `gp forward-port <port>` can be used to forward all traffic form a socket listing on all network interfaces to your process listening on localhost only.
-
-## Await Port
-
-When writing tasks to be executed on workspace start, one sometimes wants to wait for an http service to be available. `gp await-port` does that.
-
-Here's an example that will open a certain path once a service is a available:
-
-```sh
-gp await-port 3000 && gp preview $(gp url 3000)/my/path/index.html
-```
 
 ## sync-await
 
@@ -160,4 +141,25 @@ Outputs a table-formatted list of ports along with their status, URL, name and d
 
 ```sh
 gp ports list
+```
+
+### expose
+
+In Gitpod, services/servers running on a port need to be _exposed_ before they become accessible from the internet. This process only works with services listening on `0.0.0.0` and not just `localhost`.
+Sometimes it is not possible to make a server listen on `0.0.0.0`, e.g. because it is not your code and there are simply no means of configuration.
+
+In that case, `gp ports expose <port>` can be used to forward all traffic form a socket listing on all network interfaces to your process listening on localhost only.
+
+```sh
+gp ports expose <port>
+```
+
+### await
+
+When writing tasks to be executed on workspace start, one sometimes wants to wait for an http service to be available. `gp ports await` does that.
+
+Here's an example that will open a certain path once a service is a available:
+
+```sh
+gp ports await 3000 && gp preview $(gp url 3000)/my/path/index.html
 ```

--- a/gitpod/docs/config-start-tasks.md
+++ b/gitpod/docs/config-start-tasks.md
@@ -171,7 +171,7 @@ tasks:
 
 Let's say you have a web app dev server that takes a moment to start up to listen on port 3000. Once it's up and running, you want to run end-to-end tests against `http://localhost:3000`.
 
-You can achieve this with two terminals and the `gp await-port` CLI command.
+You can achieve this with two terminals and the `gp ports await` CLI command.
 
 ```yaml
 tasks:
@@ -181,7 +181,7 @@ tasks:
 
   - name: e2e Tests
     command: |
-      gp await-port 3000
+      gp ports await 3000
       npm run test
 ```
 


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/10538 PR moved `await-port` functionality to `ports await` and `forward-port`; now renamed `expose`, to `ports expose`

Previously:
- `gp forward-port <port>`
- `gp await-port <port>`

Now:
- `gp ports expose <port>`
- `gp ports await <port>`

## Related Issue(s)

Fixes #2173

## How to test

``` sh
❯ gp ports expose --help
Makes a port available on 0.0.0.0 so that it can be exposed to the internet

Usage:
  gp ports expose <local-port> [target-port] [flags]

Flags:
  -h, --help                  help for expose
  -r, --rewrite-host-header   rewrites the host header of passing HTTP requests to localhost
```

``` sh
❯ gp ports await --help
Waits for a process to listen on a port

Usage:
  gp ports await <port> [flags]

Flags:
  -h, --help   help for await
```

## Release Notes

```release-note
Update forward and await to new subcommands in ports namespace
```

## Not Changed

Haven't changed the following because I am not sure about the protocols

`.gitpod.yml`
https://github.com/gitpod-io/website/blob/2424bf22331d60cd4ba269e331104a26dab1231d/.gitpod.yml#L18

`blog`
https://github.com/gitpod-io/website/blob/2424bf22331d60cd4ba269e331104a26dab1231d/src/routes/blog/gitpodify.md?plain=1#L351