### PR TITLE
Add documentation for `gp timeout show` command

### DIFF
--- a/gitpod/docs/command-line-interface.md
+++ b/gitpod/docs/command-line-interface.md
@@ -145,6 +145,10 @@ Extends the current workspace's timeout.
 
 The default timeout, and the ability to extend a workspace timeout depends on your [plan](https://gitpod.io/plans) or [team plan](https://gitpod.io/teams).
 
+### show
+
+Shows the current workspace's timeout. The workspace timeout may be extended using `gp timeout extend` if available on the user's [plan](https://gitpod.io/plans) or [team plan](https://gitpod.io/teams).
+
 ## ports
 
 Provides a way to manage a workspace's ports. Applies to both: ports defined in [.gitpod.yml](/docs/references/gitpod-yml) and ports that are undeclared but are opened during the lifetime of the workspace.


### PR DESCRIPTION
## Description

Add a small section to the CLI docs to document the new `gp timeout show` command (https://github.com/gitpod-io/gitpod/pull/10782).

## Related Issue(s)

https://github.com/gitpod-io/gitpod/pull/10782

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2292"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2292"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

