### PR TITLE
Experiment: IDE toggle

### DIFF
--- a/gitpod/docs/config-ports.md
+++ b/gitpod/docs/config-ports.md
@@ -5,6 +5,7 @@ title: Configure Ports
 
 <script context="module">
   export const prerender = true;
+  import IdeToggle from "$lib/components/docs/ide-toggle.svelte";
 </script>
 
 # Configure Ports
@@ -96,20 +97,24 @@ The property `visibility` configures who can access a port:
 
 Port visibility can be set in [`.gitpod.yml`](/docs/references/gitpod-yml), or manually changed within the IDE or editor.
 
-### Port Visibility in VS Code Browser
+<IdeToggle id="ide-toggle-ports">
 
-<figure>
-<img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Setting a port public/private in VS Code Browser" src="/images/editors/toggle-port-visibility-vscode.png">
-    <figcaption>Setting a port public/private in VS Code Browser</figcaption>
-</figure>
-
-### Port Visibility in VS Code Desktop
-
-Currently, toggling port visibility is not possible in VS Code Desktop.
-
-### Port Visibility in JetBrains IDEs
-
+<div slot="jetbrains">
 Currently, toggling port visibility is not possible in JetBrains IDEs.
+</div>
+
+<div slot="vscodebrowser">
+    <figure>
+    <img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Setting a port public/private in VS Code Browser" src="/images/editors/toggle-port-visibility-vscode.png">
+        <figcaption>Setting a port public/private in VS Code Browser</figcaption>
+    </figure>
+</div>
+
+<div slot="vscodedesktop">
+Currently, toggling port visibility is not possible in VS Code Desktop.
+</div>
+
+</IdeToggle>
 
 ### Configure port ranges
 
@@ -131,27 +136,33 @@ There are two types of port forwarding: local and remote.
 
 Local port forwarding allows you to forward a port running in your Gitpod workspace to access via your localhost hostname. Remote port forwarding exposes a locally running process to use in your workspace. Remote port forwarding is not currently supported.
 
-### Local Port Forwarding in VS Code Browser
+### Local port forwarding
 
-Using the [Local Companion](/docs/ides-and-editors/local-companion), you can automatically forward all ports from your workspace to localhost. Setting up port forwarding for VS Code Browser allows you to use a project already configured with localhost without requiring any code changes.
+<IdeToggle id="ide-toggle-ports">
 
-### Local Port Forwarding in VS Code Desktop
+<div slot="jetbrains">
+    To forward a port in JetBrains, navigate to the preferences page in the [JetBrains Gateway](/docs/ides-and-editors/jetbrains-gateway) client to select the port and protocol to be forwarded.
+    <figure>
+    <img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in a JetBrains IDE" src="/images/jetbrains-gateway/port-forward-jetbrains.png">
+        <figcaption>Port forwarding in a JetBrains IDE</figcaption>
+    </figure>
+</div>
 
-With VS Code Desktop, all ports are automatically forwarded, allowing you to access any forwarded ports on your localhost address. You can also manually forward a port using the ports view.
+<div slot="vscodebrowser">
+    Using the [Local Companion](/docs/ides-and-editors/local-companion), you can automatically forward all ports from your workspace to localhost. Setting up port forwarding for VS Code Browser allows you to use a project already configured with localhost without requiring any code changes.
+</div>
 
-<figure>
-<img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in VS Code Desktop" src="/images/editors/port-forwarding-vscode-desktop.png">
-    <figcaption>Port forwarding in VS Code Desktop</figcaption>
-</figure>
+<div slot="vscodedesktop">
+    With VS Code Desktop, all ports are automatically forwarded, allowing you to access any forwarded ports on your localhost address. You can also manually forward a port using the ports view.
 
-### Local Port Forwarding in JetBrains IDEs
+    <figure>
+    <img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in VS Code Desktop" src="/images/editors/port-forwarding-vscode-desktop.png">
+        <figcaption>Port forwarding in VS Code Desktop</figcaption>
+    </figure>
 
-To forward a port in JetBrains, navigate to the preferences page in the [JetBrains Gateway](/docs/ides-and-editors/jetbrains-gateway) client to select the port and protocol to be forwarded.
+</div>
 
-<figure>
-<img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in a JetBrains IDE" src="/images/jetbrains-gateway/port-forward-jetbrains.png">
-    <figcaption>Port forwarding in a JetBrains IDE</figcaption>
-</figure>
+</IdeToggle>
 
 ### Local Port Forwarding via SSH
 

--- a/gitpod/docs/config-ports.md
+++ b/gitpod/docs/config-ports.md
@@ -70,7 +70,7 @@ ports:
     onOpen: open-browser
 ```
 
-### Specifying Port Names & Descriptions
+### Specifying port names & descriptions
 
 You can give ports a `name` and a `description` (both optional). These properties will help you to add context about what the port is being used for.
 
@@ -100,7 +100,7 @@ Port visibility can be set in [`.gitpod.yml`](/docs/references/gitpod-yml), or m
 <IdeToggle id="ide-toggle-ports">
 
 <div slot="jetbrains">
-Currently, toggling port visibility is not possible in JetBrains IDEs.
+    Currently, toggling port visibility is not possible in JetBrains IDEs.
 </div>
 
 <div slot="vscodebrowser">
@@ -111,7 +111,7 @@ Currently, toggling port visibility is not possible in JetBrains IDEs.
 </div>
 
 <div slot="vscodedesktop">
-Currently, toggling port visibility is not possible in VS Code Desktop.
+    Currently, toggling port visibility is not possible in VS Code Desktop.
 </div>
 
 </IdeToggle>
@@ -130,7 +130,7 @@ ports:
     onOpen: ignore
 ```
 
-## Port Forwarding
+## Port forwarding
 
 There are two types of port forwarding: local and remote.
 
@@ -141,7 +141,7 @@ Local port forwarding allows you to forward a port running in your Gitpod worksp
 <IdeToggle id="ide-toggle-ports">
 
 <div slot="jetbrains">
-    To forward a port in JetBrains, navigate to the preferences page in the [JetBrains Gateway](/docs/ides-and-editors/jetbrains-gateway) client to select the port and protocol to be forwarded.
+    <p>To forward a port in JetBrains, navigate to the preferences page in the <a href="/docs/ides-and-editors/jetbrains-gateway">JetBrains Gateway</a> client to select the port and protocol to be forwarded.</p>
     <figure>
     <img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in a JetBrains IDE" src="/images/jetbrains-gateway/port-forward-jetbrains.png">
         <figcaption>Port forwarding in a JetBrains IDE</figcaption>
@@ -149,11 +149,11 @@ Local port forwarding allows you to forward a port running in your Gitpod worksp
 </div>
 
 <div slot="vscodebrowser">
-    Using the [Local Companion](/docs/ides-and-editors/local-companion), you can automatically forward all ports from your workspace to localhost. Setting up port forwarding for VS Code Browser allows you to use a project already configured with localhost without requiring any code changes.
+    <p>Using the <a href="/docs/ides-and-editors/local-companion">Local Companion</a>, you can automatically forward all ports from your workspace to localhost. Setting up port forwarding for VS Code Browser allows you to use a project already configured with <code>localhost</code> without requiring any code changes.</p>
 </div>
 
 <div slot="vscodedesktop">
-    With VS Code Desktop, all ports are automatically forwarded, allowing you to access any forwarded ports on your localhost address. You can also manually forward a port using the ports view.
+    <p>With VS Code Desktop, all ports are automatically forwarded, allowing you to access any forwarded ports on your localhost address. You can also manually forward a port using the ports view.</p>
 
     <figure>
     <img class="shadow-medium w-full rounded-xl max-w-3xl mt-x-small" alt="Port forwarding in VS Code Desktop" src="/images/editors/port-forwarding-vscode-desktop.png">
@@ -164,7 +164,7 @@ Local port forwarding allows you to forward a port running in your Gitpod worksp
 
 </IdeToggle>
 
-### Local Port Forwarding via SSH
+### Local port forwarding via SSH
 
 Using [SSH command-line](/docs/ides-and-editors/command-line) access to your workspace, ports can also be forwarded manually using tools such as the OpenSSH remote login client.
 

--- a/src/lib/components/docs/cloud-platform-toggle.svelte
+++ b/src/lib/components/docs/cloud-platform-toggle.svelte
@@ -36,7 +36,7 @@
 
 <style lang="postcss">
   .box {
-    @apply px-4 py-2 rounded-b-2xl rounded-tr-2xl border-t-0;
+    @apply px-4 py-4 rounded-b-2xl rounded-tr-2xl border-t-0;
   }
 
   li {

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -49,10 +49,14 @@
 <div class="my-8 mt-0">
   <header>
     <nav>
-      <ul class="flex flex-wrap !pl-0 !mb-0">
+      <ul class="flex flex-wrap !pl-0 !mb-0" role="tablist">
         {#each items as item}
           {#if Object.keys($$slots).includes(item.slotName)}
-            <li class="!before:hidden">
+            <li
+              class="!before:hidden"
+              role="tab"
+              aria-selected={item.value === activeValue}
+            >
               <span
                 tabindex="0"
                 class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
@@ -77,13 +81,13 @@
   </header>
   {#if $$slots.vscodebrowser}
     {#if activeValue === 1}
-      <article class="box bg-white dark:bg-card">
+      <article class="box bg-white dark:bg-card" role="tabpanel">
         <slot name="vscodebrowser" />
       </article>
     {/if}
     {#if $$slots.vscodedesktop}
       {#if activeValue === 2}
-        <article class="box bg-white dark:bg-card">
+        <article class="box bg-white dark:bg-card" role="tabpanel">
           <slot name="vscodedesktop" />
         </article>
       {/if}
@@ -91,7 +95,7 @@
   {/if}
   {#if $$slots.jetbrains}
     {#if activeValue === 3}
-      <article class="box bg-white dark:bg-card">
+      <article class="box bg-white dark:bg-card" role="tabpanel">
         <slot name="jetbrains" />
       </article>
     {/if}

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -79,6 +79,14 @@
           ].focus();
         }
         break;
+      case "Numpad7":
+        e.preventDefault();
+        activeValue = switchableIndexes[0];
+        break;
+      case "Numpad1":
+        e.preventDefault();
+        activeValue = switchableIndexes[switchableIndexes.length - 1];
+        break;
     }
   };
 

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -139,4 +139,11 @@
       </article>
     {/if}
   {/if}
+  {#if $$slots.commandline}
+    {#if activeValue === 4}
+      <article class="box bg-white dark:bg-card" role="tabpanel">
+        <slot name="commandline" />
+      </article>
+    {/if}
+  {/if}
 </div>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -33,6 +33,40 @@
 
   const clickHandler = (tabValue: number) => () => (activeValue = tabValue);
 
+  const switchableIndexes = items
+    .filter((item) => Object.keys($$slots).includes(item.slotName))
+    .map((item) => item.value);
+
+  const switchHandler = (e: KeyboardEvent) => {
+    const currentIndex = switchableIndexes.indexOf(activeValue);
+    //@ts-ignore
+    const siblings = e.target.parentElement.children;
+    switch (e.code) {
+      case "ArrowRight":
+        {
+          e.preventDefault();
+          const willOverflow = currentIndex === switchableIndexes.length - 1;
+          activeValue = willOverflow
+            ? switchableIndexes[0]
+            : switchableIndexes[currentIndex + 1];
+          siblings[willOverflow ? 0 : currentIndex + 1].focus();
+        }
+        break;
+      case "ArrowLeft":
+        {
+          e.preventDefault();
+          const willOverflow = currentIndex === 0;
+          activeValue = willOverflow
+            ? switchableIndexes[switchableIndexes.length - 1]
+            : switchableIndexes[currentIndex - 1];
+          siblings[
+            willOverflow ? switchableIndexes.length - 1 : currentIndex - 1
+          ].focus();
+        }
+        break;
+    }
+  };
+
   export let id = "ide-toggle";
 </script>
 
@@ -49,22 +83,27 @@
 <div class="my-8 mt-0">
   <header>
     <nav>
-      <ul class="flex flex-wrap !pl-0 !mb-0" role="tablist">
+      <ul
+        class="flex flex-wrap !pl-0 !mb-0"
+        role="tablist"
+        on:keydown={switchHandler}
+      >
         {#each items as item}
           {#if Object.keys($$slots).includes(item.slotName)}
             <li
               class="!before:hidden"
               role="tab"
               aria-selected={item.value === activeValue}
+              tabindex="0"
+              on:click={clickHandler(item.value)}
+              on:focus={clickHandler(item.value)}
             >
               <span
-                tabindex="0"
                 class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
                 item.value
                   ? 'bg-white dark:bg-card'
                   : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
-                on:click={clickHandler(item.value)}
-                on:focus={clickHandler(item.value)}>{item.title}</span
+                >{item.title}</span
               >
               <span
                 class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -124,12 +124,12 @@
         <slot name="vscodebrowser" />
       </article>
     {/if}
-    {#if $$slots.vscodedesktop}
-      {#if activeValue === 2}
-        <article class="box bg-white dark:bg-card" role="tabpanel">
-          <slot name="vscodedesktop" />
-        </article>
-      {/if}
+  {/if}
+  {#if $$slots.vscodedesktop}
+    {#if activeValue === 2}
+      <article class="box bg-white dark:bg-card" role="tabpanel">
+        <slot name="vscodedesktop" />
+      </article>
     {/if}
   {/if}
   {#if $$slots.jetbrains}

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -62,14 +62,14 @@
               class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
               item.value
                 ? 'bg-white dark:bg-card'
-                : 'bg-sand-dark'} transition-all duration-200"
+                : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
               on:click={clickHandler(item.value)}>{item.title}</span
             >
             <span
               class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
               item.value
                 ? 'bg-white dark:bg-card'
-                : 'bg-sand-dark'} transition-all duration-200"
+                : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
               on:click={clickHandler(item.value)}>{item.mobileTitle}</span
             >
           </li>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -47,28 +47,34 @@
 </style>
 
 <div class="my-8 mt-0">
-  <ul class="flex flex-wrap !pl-0 !mb-0">
-    {#each items as item}
-      {#if Object.keys($$slots).includes(item.slotName)}
-        <li class="!before:hidden">
-          <span
-            class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
-            item.value
-              ? 'bg-white dark:bg-card'
-              : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
-            on:click={clickHandler(item.value)}>{item.title}</span
-          >
-          <span
-            class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
-            item.value
-              ? 'bg-white dark:bg-card'
-              : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
-            on:click={clickHandler(item.value)}>{item.mobileTitle}</span
-          >
-        </li>
-      {/if}
-    {/each}
-  </ul>
+  <header>
+    <nav>
+      <ul class="flex flex-wrap !pl-0 !mb-0">
+        {#each items as item}
+          {#if Object.keys($$slots).includes(item.slotName)}
+            <li class="!before:hidden">
+              <span
+                tabindex="0"
+                class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
+                item.value
+                  ? 'bg-white dark:bg-card'
+                  : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
+                on:click={clickHandler(item.value)}
+                on:focus={clickHandler(item.value)}>{item.title}</span
+              >
+              <span
+                class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
+                item.value
+                  ? 'bg-white dark:bg-card'
+                  : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
+                on:click={clickHandler(item.value)}>{item.mobileTitle}</span
+              >
+            </li>
+          {/if}
+        {/each}
+      </ul>
+    </nav>
+  </header>
   {#if $$slots.jetbrains}
     {#if activeValue === 1}
       <div class="box bg-white dark:bg-card">

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -5,27 +5,27 @@
 
   export let items: comparisonItem[] = [
     {
-      mobileTitle: "JetBrains",
-      title: "JetBrains",
-      value: 1,
-      slotName: "jetbrains",
-    },
-    {
       mobileTitle: "VS Code Web",
       title: "VS Code Browser",
-      value: 2,
+      value: 1,
       slotName: "vscodebrowser",
     },
     {
       mobileTitle: "VS Code",
       title: "VS Code Desktop",
-      value: 3,
+      value: 2,
       slotName: "vscodedesktop",
+    },
+    {
+      mobileTitle: "JetBrains",
+      title: "JetBrains",
+      value: 3,
+      slotName: "jetbrains",
     },
     {
       mobileTitle: "Command Line",
       title: "Command Line",
-      value: 3,
+      value: 4,
       slotName: "commandline",
     },
   ];
@@ -75,24 +75,24 @@
       </ul>
     </nav>
   </header>
-  {#if $$slots.jetbrains}
-    {#if activeValue === 1}
-      <article class="box bg-white dark:bg-card">
-        <slot name="jetbrains" />
-      </article>
-    {/if}
-  {/if}
   {#if $$slots.vscodebrowser}
-    {#if activeValue === 2}
+    {#if activeValue === 1}
       <article class="box bg-white dark:bg-card">
         <slot name="vscodebrowser" />
       </article>
     {/if}
+    {#if $$slots.vscodedesktop}
+      {#if activeValue === 2}
+        <article class="box bg-white dark:bg-card">
+          <slot name="vscodedesktop" />
+        </article>
+      {/if}
+    {/if}
   {/if}
-  {#if $$slots.vscodedesktop}
+  {#if $$slots.jetbrains}
     {#if activeValue === 3}
       <article class="box bg-white dark:bg-card">
-        <slot name="vscodedesktop" />
+        <slot name="jetbrains" />
       </article>
     {/if}
   {/if}

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -36,12 +36,12 @@
   let ariaIds: any = { tab: {}, tabpanel: {} };
 
   const getUnusedId = (() => {
-    let counter = 1;
+    let counter = { tab: 1, tabpanel: 1 };
     return (name: string, role: "tab" | "tabpanel") => {
       let theId: string;
       while (
         globalThis["document"] &&
-        document?.getElementById((theId = `${role}-${counter++}`))
+        document?.getElementById((theId = `${role}-${counter[role]++}`))
       );
       ariaIds[role][name] = theId;
       return theId;

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -79,11 +79,11 @@
           ].focus();
         }
         break;
-      case "Numpad7":
+      case "Home":
         e.preventDefault();
         activeValue = switchableIndexes[0];
         break;
-      case "Numpad1":
+      case "End":
         e.preventDefault();
         activeValue = switchableIndexes[switchableIndexes.length - 1];
         break;
@@ -118,7 +118,7 @@
               role="tab"
               aria-selected={item.value === activeValue}
               aria-controls={ariaIds.tabpanel[item.slotName]}
-              tabindex="0"
+              tabindex={item.value === activeValue ? 0 : -1}
               on:click={clickHandler(item.value)}
               on:focus={clickHandler(item.value)}
               id={getUnusedId(item.slotName, "tab")}
@@ -147,8 +147,8 @@
     <article
       class={`box bg-white dark:bg-card ${activeValue !== 1 ? "hidden" : ""}`}
       {...activeValue !== 1
-        ? { hidden: true, "aria-hidden": "true" }
-        : { hidden: false, "aria-hidden": "false" }}
+        ? { hidden: true, "aria-hidden": "true", tabindex: -1 }
+        : { hidden: false, "aria-hidden": "false", tabindex: 0 }}
       aria-labelledby={ariaIds?.tab?.vscodebrowser}
       id={getUnusedId("vscodebrowser", "tabpanel")}
       role="tabpanel"
@@ -160,8 +160,8 @@
     <article
       class={`box bg-white dark:bg-card ${activeValue !== 2 ? "hidden" : ""}`}
       {...activeValue !== 2
-        ? { hidden: true, "aria-hidden": "true" }
-        : { hidden: false, "aria-hidden": "false" }}
+        ? { hidden: true, "aria-hidden": "true", tabindex: -1 }
+        : { hidden: false, "aria-hidden": "false", tabindex: 0 }}
       aria-labelledby={ariaIds?.tab?.vscodedesktop}
       id={getUnusedId("vscodedesktop", "tabpanel")}
       role="tabpanel"
@@ -173,8 +173,8 @@
     <article
       class={`box bg-white dark:bg-card ${activeValue !== 3 ? "hidden" : ""}`}
       {...activeValue !== 3
-        ? { hidden: true, "aria-hidden": "true" }
-        : { hidden: false, "aria-hidden": "false" }}
+        ? { hidden: true, "aria-hidden": "true", tabindex: -1 }
+        : { hidden: false, "aria-hidden": "false", tabindex: 0 }}
       aria-labelledby={ariaIds?.tab?.jetbrains}
       id={getUnusedId("jetbrains", "tabpanel")}
       role="tabpanel"
@@ -186,8 +186,8 @@
     <article
       class={`box bg-white dark:bg-card ${activeValue !== 4 ? "hidden" : ""}`}
       {...activeValue !== 4
-        ? { hidden: true, "aria-hidden": "true" }
-        : { hidden: false, "aria-hidden": "false" }}
+        ? { hidden: true, "aria-hidden": "true", tabindex: -1 }
+        : { hidden: false, "aria-hidden": "false", tabindex: 0 }}
       aria-labelledby={ariaIds?.tab?.commandline}
       id={getUnusedId("commandline", "tabpanel")}
       role="tabpanel"

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  // Couldn't create this component entirely dynamic, because Slots can't be named dynamically
+  // Had to use !important to make sure the styles from tailwinds prose-class are overridden
+  import type { comparisonItem } from "$lib/types/docs.type";
+
+  export let items: comparisonItem[] = [
+    {
+      mobileTitle: "JetBrains",
+      title: "JetBrains",
+      value: 1,
+      slotName: "jetbrains",
+    },
+    {
+      mobileTitle: "VS Code Browser",
+      title: "VS Code Browser",
+      value: 2,
+      slotName: "vscodebrowser",
+    },
+    {
+      mobileTitle: "VS Code Desktop",
+      title: "VS Code Desktop",
+      value: 3,
+      slotName: "vscodedesktop",
+    },
+    {
+      mobileTitle: "Command Line",
+      title: "Command Line",
+      value: 3,
+      slotName: "commandline",
+    },
+  ];
+  let activeValue = 1;
+
+  const clickHandler = (tabValue: number) => () => (activeValue = tabValue);
+
+  export let id = "ide-toggle";
+
+  export let open = true;
+</script>
+
+<style lang="postcss">
+  .box {
+    @apply px-4 py-2 rounded-b-2xl rounded-tr-2xl border-t-0;
+  }
+
+  li {
+    @apply before:hidden m-0 p-0 !important;
+  }
+</style>
+
+<details open={open || null} {id}>
+  <summary class="text-p-medium">
+    Configuration for JetBrains, VS Code Desktop, VS Code
+  </summary>
+
+  <div class="my-8 mt-0">
+    <ul class="flex flex-wrap !pl-0 !mb-0">
+      {#each items as item}
+        {#if Object.keys($$slots).includes(item.slotName)}
+          <li class="!before:hidden">
+            <span
+              class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
+              item.value
+                ? 'bg-white dark:bg-card'
+                : 'bg-sand-dark'} transition-all duration-200"
+              on:click={clickHandler(item.value)}>{item.title}</span
+            >
+            <span
+              class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
+              item.value
+                ? 'bg-white dark:bg-card'
+                : 'bg-sand-dark'} transition-all duration-200"
+              on:click={clickHandler(item.value)}>{item.mobileTitle}</span
+            >
+          </li>
+        {/if}
+      {/each}
+    </ul>
+    {#if $$slots.jetbrains}
+      {#if activeValue === 1}
+        <div class="box bg-white dark:bg-card">
+          <slot name="jetbrains" />
+        </div>
+      {/if}
+    {/if}
+    {#if $$slots.vscodebrowser}
+      {#if activeValue === 2}
+        <div class="box bg-white dark:bg-card">
+          <slot name="vscodebrowser" />
+        </div>
+      {/if}
+    {/if}
+    {#if $$slots.vscodedesktop}
+      {#if activeValue === 3}
+        <div class="box bg-white dark:bg-card">
+          <slot name="vscodedesktop" />
+        </div>
+      {/if}
+    {/if}
+    {#if $$slots.commandline}
+      {#if activeValue === 4}
+        <div class="box bg-white dark:bg-card">
+          <slot name="commandline" />
+        </div>
+      {/if}
+    {/if}
+  </div>
+</details>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -11,13 +11,13 @@
       slotName: "jetbrains",
     },
     {
-      mobileTitle: "VS Code Browser",
+      mobileTitle: "VS Code Web",
       title: "VS Code Browser",
       value: 2,
       slotName: "vscodebrowser",
     },
     {
-      mobileTitle: "VS Code Desktop",
+      mobileTitle: "VS Code",
       title: "VS Code Desktop",
       value: 3,
       slotName: "vscodedesktop",
@@ -34,8 +34,6 @@
   const clickHandler = (tabValue: number) => () => (activeValue = tabValue);
 
   export let id = "ide-toggle";
-
-  export let open = true;
 </script>
 
 <style lang="postcss">
@@ -48,61 +46,48 @@
   }
 </style>
 
-<details open={open || null} {id}>
-  <summary class="text-p-medium">
-    Configuration for JetBrains, VS Code Desktop, VS Code
-  </summary>
-
-  <div class="my-8 mt-0">
-    <ul class="flex flex-wrap !pl-0 !mb-0">
-      {#each items as item}
-        {#if Object.keys($$slots).includes(item.slotName)}
-          <li class="!before:hidden">
-            <span
-              class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
-              item.value
-                ? 'bg-white dark:bg-card'
-                : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
-              on:click={clickHandler(item.value)}>{item.title}</span
-            >
-            <span
-              class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
-              item.value
-                ? 'bg-white dark:bg-card'
-                : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
-              on:click={clickHandler(item.value)}>{item.mobileTitle}</span
-            >
-          </li>
-        {/if}
-      {/each}
-    </ul>
-    {#if $$slots.jetbrains}
-      {#if activeValue === 1}
-        <div class="box bg-white dark:bg-card">
-          <slot name="jetbrains" />
-        </div>
+<div class="my-8 mt-0">
+  <ul class="flex flex-wrap !pl-0 !mb-0">
+    {#each items as item}
+      {#if Object.keys($$slots).includes(item.slotName)}
+        <li class="!before:hidden">
+          <span
+            class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
+            item.value
+              ? 'bg-white dark:bg-card'
+              : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
+            on:click={clickHandler(item.value)}>{item.title}</span
+          >
+          <span
+            class="rounded-t-2xl cursor-pointer px-4 py-2 md:hidden block {activeValue ===
+            item.value
+              ? 'bg-white dark:bg-card'
+              : 'bg-sand-dark dark:bg-light-black'} transition-all duration-200"
+            on:click={clickHandler(item.value)}>{item.mobileTitle}</span
+          >
+        </li>
       {/if}
+    {/each}
+  </ul>
+  {#if $$slots.jetbrains}
+    {#if activeValue === 1}
+      <div class="box bg-white dark:bg-card">
+        <slot name="jetbrains" />
+      </div>
     {/if}
-    {#if $$slots.vscodebrowser}
-      {#if activeValue === 2}
-        <div class="box bg-white dark:bg-card">
-          <slot name="vscodebrowser" />
-        </div>
-      {/if}
+  {/if}
+  {#if $$slots.vscodebrowser}
+    {#if activeValue === 2}
+      <div class="box bg-white dark:bg-card">
+        <slot name="vscodebrowser" />
+      </div>
     {/if}
-    {#if $$slots.vscodedesktop}
-      {#if activeValue === 3}
-        <div class="box bg-white dark:bg-card">
-          <slot name="vscodedesktop" />
-        </div>
-      {/if}
+  {/if}
+  {#if $$slots.vscodedesktop}
+    {#if activeValue === 3}
+      <div class="box bg-white dark:bg-card">
+        <slot name="vscodedesktop" />
+      </div>
     {/if}
-    {#if $$slots.commandline}
-      {#if activeValue === 4}
-        <div class="box bg-white dark:bg-card">
-          <slot name="commandline" />
-        </div>
-      {/if}
-    {/if}
-  </div>
-</details>
+  {/if}
+</div>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -33,6 +33,21 @@
 
   const clickHandler = (tabValue: number) => () => (activeValue = tabValue);
 
+  let ariaIds: any = { tab: {}, tabpanel: {} };
+
+  const getUnusedId = (() => {
+    let counter = 1;
+    return (name: string, role: "tab" | "tabpanel") => {
+      let theId: string;
+      while (
+        globalThis["document"] &&
+        document?.getElementById((theId = `${role}-${counter++}`))
+      );
+      ariaIds[role][name] = theId;
+      return theId;
+    };
+  })();
+
   const switchableIndexes = items
     .filter((item) => Object.keys($$slots).includes(item.slotName))
     .map((item) => item.value);
@@ -94,9 +109,11 @@
               class="!before:hidden"
               role="tab"
               aria-selected={item.value === activeValue}
+              aria-controls={ariaIds.tabpanel[item.slotName]}
               tabindex="0"
               on:click={clickHandler(item.value)}
               on:focus={clickHandler(item.value)}
+              id={getUnusedId(item.slotName, "tab")}
             >
               <span
                 class="rounded-t-2xl cursor-pointer px-4 py-2 hidden md:block {activeValue ===
@@ -124,6 +141,8 @@
       {...activeValue !== 1
         ? { hidden: true, "aria-hidden": "true" }
         : { hidden: false, "aria-hidden": "false" }}
+      aria-labelledby={ariaIds?.tab?.vscodebrowser}
+      id={getUnusedId("vscodebrowser", "tabpanel")}
       role="tabpanel"
     >
       <slot name="vscodebrowser" />
@@ -135,6 +154,8 @@
       {...activeValue !== 2
         ? { hidden: true, "aria-hidden": "true" }
         : { hidden: false, "aria-hidden": "false" }}
+      aria-labelledby={ariaIds?.tab?.vscodedesktop}
+      id={getUnusedId("vscodedesktop", "tabpanel")}
       role="tabpanel"
     >
       <slot name="vscodedesktop" />
@@ -146,6 +167,8 @@
       {...activeValue !== 3
         ? { hidden: true, "aria-hidden": "true" }
         : { hidden: false, "aria-hidden": "false" }}
+      aria-labelledby={ariaIds?.tab?.jetbrains}
+      id={getUnusedId("jetbrains", "tabpanel")}
       role="tabpanel"
     >
       <slot name="jetbrains" />
@@ -157,6 +180,8 @@
       {...activeValue !== 4
         ? { hidden: true, "aria-hidden": "true" }
         : { hidden: false, "aria-hidden": "false" }}
+      aria-labelledby={ariaIds?.tab?.commandline}
+      id={getUnusedId("commandline", "tabpanel")}
       role="tabpanel"
     >
       <slot name="commandline" />

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -38,7 +38,7 @@
 
 <style lang="postcss">
   .box {
-    @apply px-4 py-2 rounded-b-2xl rounded-tr-2xl border-t-0;
+    @apply px-4 py-4 rounded-b-2xl rounded-tr-2xl border-t-0;
   }
 
   li {

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -77,23 +77,23 @@
   </header>
   {#if $$slots.jetbrains}
     {#if activeValue === 1}
-      <div class="box bg-white dark:bg-card">
+      <article class="box bg-white dark:bg-card">
         <slot name="jetbrains" />
-      </div>
+      </article>
     {/if}
   {/if}
   {#if $$slots.vscodebrowser}
     {#if activeValue === 2}
-      <div class="box bg-white dark:bg-card">
+      <article class="box bg-white dark:bg-card">
         <slot name="vscodebrowser" />
-      </div>
+      </article>
     {/if}
   {/if}
   {#if $$slots.vscodedesktop}
     {#if activeValue === 3}
-      <div class="box bg-white dark:bg-card">
+      <article class="box bg-white dark:bg-card">
         <slot name="vscodedesktop" />
-      </div>
+      </article>
     {/if}
   {/if}
 </div>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -119,31 +119,47 @@
     </nav>
   </header>
   {#if $$slots.vscodebrowser}
-    {#if activeValue === 1}
-      <article class="box bg-white dark:bg-card" role="tabpanel">
-        <slot name="vscodebrowser" />
-      </article>
-    {/if}
+    <article
+      class={`box bg-white dark:bg-card ${activeValue !== 1 ? "hidden" : ""}`}
+      {...activeValue !== 1
+        ? { hidden: true, "aria-hidden": "true" }
+        : { hidden: false, "aria-hidden": "false" }}
+      role="tabpanel"
+    >
+      <slot name="vscodebrowser" />
+    </article>
   {/if}
   {#if $$slots.vscodedesktop}
-    {#if activeValue === 2}
-      <article class="box bg-white dark:bg-card" role="tabpanel">
-        <slot name="vscodedesktop" />
-      </article>
-    {/if}
+    <article
+      class={`box bg-white dark:bg-card ${activeValue !== 2 ? "hidden" : ""}`}
+      {...activeValue !== 2
+        ? { hidden: true, "aria-hidden": "true" }
+        : { hidden: false, "aria-hidden": "false" }}
+      role="tabpanel"
+    >
+      <slot name="vscodedesktop" />
+    </article>
   {/if}
   {#if $$slots.jetbrains}
-    {#if activeValue === 3}
-      <article class="box bg-white dark:bg-card" role="tabpanel">
-        <slot name="jetbrains" />
-      </article>
-    {/if}
+    <article
+      class={`box bg-white dark:bg-card ${activeValue !== 3 ? "hidden" : ""}`}
+      {...activeValue !== 3
+        ? { hidden: true, "aria-hidden": "true" }
+        : { hidden: false, "aria-hidden": "false" }}
+      role="tabpanel"
+    >
+      <slot name="jetbrains" />
+    </article>
   {/if}
   {#if $$slots.commandline}
-    {#if activeValue === 4}
-      <article class="box bg-white dark:bg-card" role="tabpanel">
-        <slot name="commandline" />
-      </article>
-    {/if}
+    <article
+      class={`box bg-white dark:bg-card ${activeValue !== 4 ? "hidden" : ""}`}
+      {...activeValue !== 4
+        ? { hidden: true, "aria-hidden": "true" }
+        : { hidden: false, "aria-hidden": "false" }}
+      role="tabpanel"
+    >
+      <slot name="commandline" />
+    </article>
   {/if}
 </div>

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -35,14 +35,15 @@
 
   let ariaIds: any = { tab: {}, tabpanel: {} };
 
+  if (!globalThis.counter) {
+    globalThis.counter = { tab: 1, tabpanel: 1 };
+  }
+
   const getUnusedId = (() => {
-    let counter = { tab: 1, tabpanel: 1 };
+    //@ts-ignore
+    let { counter } = globalThis;
     return (name: string, role: "tab" | "tabpanel") => {
-      let theId: string;
-      while (
-        globalThis["document"] &&
-        document?.getElementById((theId = `${role}-${counter[role]++}`))
-      );
+      const theId = `${role}-${counter[role]++}`;
       ariaIds[role][name] = theId;
       return theId;
     };


### PR DESCRIPTION
In a few places in the docs we have separate sections for each IDE, this introduces a toggle to showcase the different IDEs. 

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/5528307/175524279-1d95cb2a-ec1d-4a19-a46a-034efe5bf3ad.png)|![image](https://user-images.githubusercontent.com/5528307/175524222-dff4502c-d065-44cc-b917-f77e68027edc.png)|

**Considerations:**  
- Headings are no longer seen in the overview (screenshots below)
- Formatting has to be HTML, not MD (So I guess we lose things like link validation?)
- Do we separate JetBrains IDEs down? Or always one section for JetBrains? 🤔 
- I have removed the toggle, as unlike on cloud, this toggle would likely always be showing different options intentionally, and not for abstracting away details. 

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/5528307/175524141-4f408f3c-031f-49e3-9304-df9585c197cc.png)|![image](https://user-images.githubusercontent.com/5528307/175524114-fe76fbcd-30f5-4638-8177-021e623213d5.png)|

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2302"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

