### PR TITLE
contact widget follow up updates

### DIFF
--- a/src/lib/components/banners/base.svelte
+++ b/src/lib/components/banners/base.svelte
@@ -35,6 +35,12 @@
         }
       }
     }
+
+    if (storageKey === "cookie-consent-bar" && showBanner) {
+      document.body.classList.add("consent-is-shown");
+    } else {
+      document.body.classList.remove("consent-is-shown");
+    }
   });
 </script>
 

--- a/src/lib/components/contact-widget.svelte
+++ b/src/lib/components/contact-widget.svelte
@@ -104,6 +104,7 @@
         on:click={() => (areButtonsShown = false)}
         in:fade={{ duration: 200, delay: 300 }}
         out:fade={{ duration: 300 }}
+        aria-label="Close the menu"
       >
         <Close class="h-6 w-6 mb-macro" />
       </button>
@@ -112,7 +113,7 @@
       in:fade={{ duration: 600 }}
       out:fade={{ duration: 300 }}
       bind:this={linksWrapper}
-      class="stroked stroked-sand flex flex-col rounded-2xl mb-xx-small links p-xx-small"
+      class="stroked stroked-sand flex flex-col rounded-2xl mb-5 sm:mb-xx-small links p-3 sm:p-xx-small"
     >
       <div class="before" />
       <div class="space-y-macro">
@@ -140,7 +141,7 @@
     <div data-analytics={`{"label":"Hide/Show Contact Widget"}`}>
       <button
         in:fade={{ duration: 200 }}
-        class="stroked flex group justify-center items-center bg-card h-14 w-14 rounded-full"
+        class="stroked flex group justify-center items-center bg-card h-12 w-12 sm:h-14 sm:w-14 rounded-full"
         on:click={() => {
           areButtonsShown = !areButtonsShown;
         }}
@@ -148,7 +149,7 @@
         <div class="icon-wrapper" bind:this={iconWrapper}>
           <svelte:component
             this={Chat}
-            class="h-8 w-8 filter group-hover:grayscale transition-all duration-200 {areButtonsShown
+            class="h-6 w-6 sm:h-8 sm:w-8 filter group-hover:grayscale transition-all duration-200 {areButtonsShown
               ? 'grayscale'
               : ''}"
           />

--- a/src/lib/components/contact-widget.svelte
+++ b/src/lib/components/contact-widget.svelte
@@ -64,6 +64,10 @@
 </script>
 
 <style lang="postcss">
+  :global(body.consent-is-shown) .parent {
+    @apply bottom-[95px] xl:bottom-14;
+  }
+
   .links {
     @apply relative;
 
@@ -91,7 +95,7 @@
 </style>
 
 <div
-  class="fixed bottom-4 right-4 flex flex-col items-end z-50"
+  class="fixed bottom-4 right-4 flex flex-col items-end z-50 parent"
   data-analytics={`{"context":"contact_widget"}`}
 >
   {#if areButtonsShown}
@@ -108,29 +112,27 @@
       in:fade={{ duration: 600 }}
       out:fade={{ duration: 300 }}
       bind:this={linksWrapper}
-      class="stroked stroked-sand flex flex-col rounded-2xl mb-xx-small"
+      class="stroked stroked-sand flex flex-col rounded-2xl mb-xx-small links p-xx-small"
     >
-      <div class="links p-xx-small">
-        <div class="before" />
-        <div class="space-y-macro">
-          {#each buttons as { href, text, icon }}
-            <LinkButton
-              {href}
-              variant="white"
-              textAlign="left"
-              class="flex items-center max-w-[205px] group"
-            >
-              <svelte:component
-                this={icon}
-                class="h-4 w-4 mr-3 filter grayscale group-hover:grayscale-0 transition-all duration-200"
-                slot="image"
-              />
-              {text}
-            </LinkButton>
-          {/each}
-        </div>
-        <div class="stroked stroked-sand after" />
+      <div class="before" />
+      <div class="space-y-macro">
+        {#each buttons as { href, text, icon }}
+          <LinkButton
+            {href}
+            variant="white"
+            textAlign="left"
+            class="flex items-center max-w-[205px] group"
+          >
+            <svelte:component
+              this={icon}
+              class="h-4 w-4 mr-3 filter grayscale group-hover:grayscale-0 transition-all duration-200"
+              slot="image"
+            />
+            {text}
+          </LinkButton>
+        {/each}
       </div>
+      <div class="stroked stroked-sand after" />
     </div>
   {/if}
 


### PR DESCRIPTION
- [x] fixes the overlapping issue with the toggle button being overlapped with Reject all button in the consent banner. 
![image](https://user-images.githubusercontent.com/46004116/176097356-3da3ee2c-087b-4855-9bb4-92f72247f5ee.png)

- [x] makes things a bit smaller for more breathing room on mobile. 

![image](https://user-images.githubusercontent.com/46004116/176103345-83c59341-521a-4f23-8889-229855c29ff0.png)



<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2318"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

