### PR TITLE
Fix Typo "Saas" to "SaaS"

### DIFF
--- a/src/lib/contents/enterprise.ts
+++ b/src/lib/contents/enterprise.ts
@@ -37,7 +37,7 @@ export const featureCards: Card[] = [
     },
   },
   {
-    title: "Saas",
+    title: "SaaS",
     text: "Gitpod, managed in the cloud for you. Secure data storage in the cloud and minimal setup cost. Scale users as you need with full flexibility.",
     icon: {
       src: "/svg/icons/cloud.svg",


### PR DESCRIPTION

## Description
Fixed Typo "Saas" to "SaaS" on for/enterprise

## Related Issue(s)
Did not create issue because change is so minor
Fixes #



## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2389"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

