### PR TITLE
Update gitlab-integration.md, replace "GitHub" with "GitLab"

### DIFF
--- a/gitpod/docs/gitlab-integration.md
+++ b/gitpod/docs/gitlab-integration.md
@@ -108,4 +108,4 @@ Here is how to register your Self-Hosted GitLab installation:
 
 <img alt="link new GitLab app to Gitpod" src="https://user-images.githubusercontent.com/372735/91142160-9f54f880-e6b0-11ea-8436-6a9c8bc67d9f.png">
 
-7. Press _Connect_ and go through the GitHub authentication flow to connect your user account.
+7. Press _Connect_ and go through the GitLab authentication flow to connect your user account.


### PR DESCRIPTION
Replace "GitHub" with "GitLab" in the GitLab integrations documentation.

## Documentation

Yes, but just a single word fix, no new feature.


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2430"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

