### PR TITLE
Update changelog template (latest + roadmap section)

### DIFF
--- a/src/lib/contents/changelog/_template.md
+++ b/src/lib/contents/changelog/_template.md
@@ -4,7 +4,7 @@ excerpt:
 date: {{releaseDate}}
 image: {{releaseDate}}.jpg
 alt:
-tag: //incase its a self-hosted Changelog add the value `self-hosted`, otherwise tis prop can be left empty
+tag: //in case its a self-hosted changelog add the value `self-hosted`, otherwise this prop can be left empty
 ---
 
 <script>

--- a/src/lib/contents/changelog/_template.md
+++ b/src/lib/contents/changelog/_template.md
@@ -14,6 +14,21 @@ TODO: Insert the featured changelog entry here.
 
 <p><Contributors usernames="" /></p>
 
+### Roadmap updates
+
+<div class="mt-medium">
+
+**FeatureName** - Roadmap issue: [#XXXX](https://github.com/gitpod-io/gitpod/issues/XXXX) <Badge text="beta" variant="orange" class="ml-1.5" />
+
+</div>
+
+### Latest 
+
+The following are beta Gitpod features not currently in [general availability](https://www.gitpod.io/docs/references/gitpod-releases). If something catches your eye, why not try it out, and let us know what you think in the [community]([url](https://community.gitpod.io/)), or if needed, [raise an issue]([url](https://github.com/gitpod-io/gitpod)).
+
+**Please note:** Some features might require a specific IDE or editor version, or certain configuration steps to be enabled. 
+
+
 ### Fixes and improvements
 
 {{fixesAndImprovements}}

--- a/src/lib/contents/changelog/_template.md
+++ b/src/lib/contents/changelog/_template.md
@@ -4,7 +4,7 @@ excerpt:
 date: {{releaseDate}}
 image: {{releaseDate}}.jpg
 alt:
-tag:
+tag: //incase its a self-hosted Changelog add the value `self-hosted`, otherwise tis prop can be left empty
 ---
 
 <script>

--- a/src/lib/contents/changelog/_template.md
+++ b/src/lib/contents/changelog/_template.md
@@ -28,6 +28,11 @@ The following are beta Gitpod features not currently in [general availability](h
 
 **Please note:** Some features might require a specific IDE or editor version, or certain configuration steps to be enabled. 
 
+### Deprecations
+
+Please ensure to update any necessary Gitpod enabled repositories, configurations or installations in accordance with the following deprecations:
+
+* **01/02/2022** - Lorem Ipsum
 
 ### Fixes and improvements
 

--- a/src/lib/contents/changelog/_template.md
+++ b/src/lib/contents/changelog/_template.md
@@ -4,6 +4,7 @@ excerpt:
 date: {{releaseDate}}
 image: {{releaseDate}}.jpg
 alt:
+tag:
 ---
 
 <script>
@@ -22,17 +23,17 @@ TODO: Insert the featured changelog entry here.
 
 </div>
 
-### Latest 
+### Latest
 
-The following are beta Gitpod features not currently in [general availability](https://www.gitpod.io/docs/references/gitpod-releases). If something catches your eye, why not try it out, and let us know what you think in the [community]([url](https://community.gitpod.io/)), or if needed, [raise an issue]([url](https://github.com/gitpod-io/gitpod)).
+The following are beta Gitpod features not currently in [general availability](https://www.gitpod.io/docs/references/gitpod-releases). If something catches your eye, why not try it out, and let us know what you think in the [community](<[url](https://community.gitpod.io/)>), or if needed, [raise an issue](<[url](https://github.com/gitpod-io/gitpod)>).
 
-**Please note:** Some features might require a specific IDE or editor version, or certain configuration steps to be enabled. 
+**Please note:** Some features might require a specific IDE or editor version, or certain configuration steps to be enabled.
 
 ### Deprecations
 
 Please ensure to update any necessary Gitpod enabled repositories, configurations or installations in accordance with the following deprecations:
 
-* **01/02/2022** - Lorem Ipsum
+- **01/02/2022** - Lorem Ipsum
 
 ### Fixes and improvements
 


### PR DESCRIPTION
Proposes some updates to the changelog template: 

1. Add **"latest"** section for early features (with instructions on how to enable, etc). 
2. Add **roadmap** section - This has been added for lots of past changelog entries but was not yet in the template. 
3. Add **deprecations** section - For upcoming features / API's to be removed. 

<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2473"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

## Context

We recently added a product changelog which is shown inside VS Code Desktop + Browser to Gitpod users: 

- https://github.com/gitpod-io/gitpod/issues/7537

We want to make sure to highlight these latest features in the changelog by adding an explicit section which would draw attention to these early / pre-release features. 

Closes: https://github.com/gitpod-io/gitpod/issues/11622