### PR TITLE
[self hosted] Document Gitpod requirement on LoadBalancer type services

### DIFF
--- a/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
+++ b/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
@@ -79,3 +79,7 @@ These are the components expected on each node:
 ### Kubernetes Privilege Requirements
 
 Your Kubernetes cluster must allow Gitpod to run privileged pods and manage PodSecurityPolicies, as Gitpod depends on these privileges to provide workspace isolation.
+
+### Load Balancer Requirements
+
+Gitpod uses [`LoadBalancer` type services](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) to expose the Gitpod Dashboard, browser based IDEs, and SSH connections used by desktop IDEs. Your Kubernetes cluster must be able to provision load balancers that can route HTTP/HTTPS and SSH connections to Gitpod services.

--- a/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
+++ b/gitpod/docs/self-hosted/latest/cluster-set-up/index.md
@@ -82,4 +82,13 @@ Your Kubernetes cluster must allow Gitpod to run privileged pods and manage PodS
 
 ### Load Balancer Requirements
 
-Gitpod uses [`LoadBalancer` type services](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) to expose the Gitpod Dashboard, browser based IDEs, and SSH connections used by desktop IDEs. Your Kubernetes cluster must be able to provision load balancers that can route HTTP/HTTPS and SSH connections to Gitpod services.
+Gitpod uses [`LoadBalancer` type services](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) to expose the Gitpod Dashboard, browser based IDEs, and SSH connections used by desktop IDEs. Your Kubernetes cluster must be able to provision layer 4 or layer 7 load balancers for `LoadBalancer` type services that can route HTTP(S) connections to Gitpod services. If you intend to use desktop IDEs or SSH to workspaces then your cluster must also be able to provision layer 4 load balancers that can route SSH connectiosn to Gitpod services.
+
+All supported Kubernetes distributions provide load balancers that meet Gitpod's needs. For more information see the Kubernetes distribution documentation below:
+
+- [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer)
+- Amazon Elastic Kubernetes Engine:
+  - Layer 4/7 (default): [Classic Load Balancer](https://aws.amazon.com/premiumsupport/knowledge-center/eks-kubernetes-services-cluster/)
+  - Layer 4 only: [Network Load Balancing](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html)
+- [Microsoft Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/concepts-network)
+- [K3s](https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer)


### PR DESCRIPTION
## Description

At present the Gitpod Kubernetes requirements do not state that Gitpod depends on load balancers that can handle both HTTP(S) and SSH connections. This pull request adds documentation that Gitpod requires layer 4 load balancers and adds links to the appropriate vendor documentation.

## Related Issue(s)

Fixes [gitpod-io/gitpod#11581](https://github.com/gitpod-io/gitpod/issues/11581)

- - -

/cc @MrSimonEmms 

This documentation doesn't fully account for the [`ClusterIP` service configuration](https://github.com/gitpod-io/gitpod/pull/11006) but we don't appear to have documented this yet; we can either roll in that documentation into this PR or address it shortly after and amend these changes with the updated configs.

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2477"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2477"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

