### PR TITLE
[PROPOSAL] docs(configure-ide): proposal for rework

### DIFF
--- a/gitpod/docs/ides-and-editors/configure-your-editor-ide.md
+++ b/gitpod/docs/ides-and-editors/configure-your-editor-ide.md
@@ -9,24 +9,35 @@ title: Configure your IDE/editor
 
 # {title}
 
-Customise the IDE or editor experience for a project, or yourself.
+Which IDE/editor is used when launching workspaces is configured via your [user preferences](https://gitpod.io/preferences) and take effect upon launching new workspaces.
 
-## Per Project
 
-Updating per-project settings are shared with anyone who starts a new gitpod workspace.
+... image of dashboard ...
 
-- Update the projects [.gitpod.yml](/docs/config-gitpod-file) file to install [VS Code extensions](/docs/references/gitpod-yml#vscode), or [JetBrains plugins](/docs/references/gitpod-yml#jetbrains).
-- Update the projects [start tasks](/docs/config-start-tasks) in `.gitpod.yml`
-- Add a custom [base image](/docs/config-docker) to your project
+... notice ... There are currently no ways to configure IDE/editor's on a per-team basis. ... link to GitHub issue/feature request...
 
-## Per User
 
-Updating per-user settings are shared only with the current user of a gitpod workspace.
 
-To configure a specific IDE or editor as a default user preference for all new workspaces, you will need to update your [user preferences](https://gitpod.io/preferences). There is currently no way to configure Gitpod to open different editors or IDEs for different projects. IDE and editor preferences only take effect for new or restarted workspaces. Changing your editor or IDE preference will not affect running workspaces.
+## Terminal / SSH
 
-Set up additional per-user configurations using [dotfiles](/docs/config-dotfiles).
+1. installation of dotfiles
 
-## Per Team
+## Visual Studio Browser
 
-There are currently no ways to configure IDE/editor's on a per-team basis.
+1. explain - configuration of plugins can be at project level
+1. explain - configuration of plugins can be at user level
+1. introduce - openvsx registry and visual studio marketplace is proprietary
+1. advice - if openvsx does not have extension how to add it
+...
+
+## Visual Studio Desktop
+
+1. explain Visual Studio desktop can access the official marketplace.
+1. introduce - `.vscode/settings.json`
+
+
+## Jetbrains
+
+1. explain - configuration of plugins can be at project level
+
+


### PR DESCRIPTION
## Description

We received the following feedback:

> Can you configure the _selection_ of an IDE per project? This page seems to imply that you can, yet https://www.gitpod.io/docs/references/gitpod-yml does not have any such apparent option. If it is _not_ an option, OK but please say so explicitly.

which prompted a content review cycle and spawned the following thoughts:

1. The page `/docs/ides-and-editors/configure-your-editor-ide` page should be completely deleted and replaced with configuration instructions as subheadings on each editor's page. See the attached changes for suggestions of what each subheading could look like.
2. The page `/ides-and-editors` should be updated with instructions on how to switch editors, switching editors is account level and there's no way to enforce configuration (why would someone want this?) at a team level.
3. Mentioning "per project configuration of Gitpod.yml" in the context of start tasks or doesn't make sense to me here unless it is in the context of "installation of custom software into the Gitpod environment aka bring your own custom docker image". Thoughts here is that any such reference should be 🆙  a level at `/ides-and-editors`

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2518"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

