### PR TITLE
Removal of the limitation on immutable labels in self-hosted customization

### DIFF
--- a/gitpod/docs/self-hosted/latest/advanced/customization.md
+++ b/gitpod/docs/self-hosted/latest/advanced/customization.md
@@ -144,6 +144,8 @@ customization:
 
 ## Limitations
 
+> This limitation has been removed as of [`2022.08.0`](https://github.com/gitpod-io/gitpod/releases/tag/2022.08.0).
+
 Labels are immutable on some Kubernetes resources, such as `Deployments`, `DaemonSets` and `StatefulSets`.
 
 If you wish to change a label on one of these resources, you must destroy that resource first. This can be achieved by running `kubectl delete <resource> --namespace <namespace> <name>` prior to running the KOTS deployment.


### PR DESCRIPTION
> Hold until August release is published

## Description
<!-- Describe your changes in detail -->
With the release of https://github.com/gitpod-io/gitpod/pull/11954, the limitation on custom labels no longer exists.

This does not remove it from the docs as it is still in supported versions of Gitpod

## How to test
<!-- Provide steps to test this PR -->
Read

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Removal of the limitation on immutable labels in self-hosted customization
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2581"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

