### PR TITLE
Corrected a typo in docs/contribute

### DIFF
--- a/gitpod/docs/contribute/index.md
+++ b/gitpod/docs/contribute/index.md
@@ -9,7 +9,7 @@ title: Contribute
 
 # Contribute
 
-The team behind Gitpod has built-in the open for the last decade. Transparency is key and as a company Gitpod strives to be as open about as many things as possible. This refers to both developing Gitpod in the open (public issues, public roadmap, public milestones) as well as how employees interact on a personal level with other human beings. Gitpodders are strong believers in the benefits that an open culture provides. At Gitpod we are open-minded, inclusive, transparent, and curious. We always remain students of the game, not masters of the game.
+The team behind Gitpod has built in the open for the last decade. Transparency is key and as a company Gitpod strives to be as open about as many things as possible. This refers to both developing Gitpod in the open (public issues, public roadmap, public milestones) as well as how employees interact on a personal level with other human beings. Gitpodders are strong believers in the benefits that an open culture provides. At Gitpod we are open-minded, inclusive, transparent, and curious. We always remain students of the game, not masters of the game.
 
 We 🧡 the people who are involved in this project, and we’d love to have you on board, especially if you are just getting started or have never contributed to open-source before. So here's to you, lovely person who wants to join us — this is how you can support us:
 


### PR DESCRIPTION
## Description

Corrected a small typo in docs/contribute:
```diff
- The team behind Gitpod has built-in the open for the last decade.
+ The team behind Gitpod has built in the open for the last decade.
```

## Related Issue(s)
N/A

## How to test
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2603"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

