### PR TITLE
Remove reference to external Twitter account

### DIFF
--- a/src/routes/vs/local-development.svelte
+++ b/src/routes/vs/local-development.svelte
@@ -58,9 +58,7 @@
 
 <GitpodVsLocalDevelopmentPost
   title="Full blog post"
-  text={`
-  Read the full blog post by <a href="https://twitter.com/mikenikles" target="_blank">Mike Nikles</a>, our Senior Developer Success Engineer, sharing the story of moving to the cloud.
-  `}
+  text="Read a first-hand developer perspective on switching to remote development."
 />
 
 <Explore />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- We don't want to move our website users to an external Twitter account. Mike Nikles no longer works at Gitpod and posts about other topics.
- Replaced with more descriptive sentence

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- Not required


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2604"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

