### PR TITLE
Add supported web browsers

### DIFF
--- a/gitpod/docs/self-hosted/latest/index.md
+++ b/gitpod/docs/self-hosted/latest/index.md
@@ -55,3 +55,15 @@ You want to use your own database, registry, object storage, or source control m
 ## Troubleshooting
 
 Refer to the [troubleshooting section](./latest/troubleshooting) for help with your Gitpod Self-Hosted Instance. You can also take a look at our [support page](/support) to learn how to reach our community and support team.
+
+## Supported web browsers
+
+Gitpod supports the **current** and **previous** major versions of the following web browsers:
+
+- Mozilla Firefox
+- Google Chrome
+- Chromium
+- Apple Safari
+- Microsoft Edge
+
+> **Note:** We don’t support running Gitpod with JavaScript disabled in the browser.


### PR DESCRIPTION
## Description

Following the [relevant but obsolete section we had in our docs](https://www.gitpod.io/docs/self-hosted/helm-deprecated/requirements#supported-web-browsers), this will add a section on our intentions to support the current and previous major versions of the following web browsers:

- Mozilla Firefox
- Google Chrome
- Chromium
- Apple Safari
- Microsoft Edge

See also [relevant discussion](https://github.com/gitpod-io/gitpod/pull/12258#discussion_r952581084). Cc @svenefftinge 

This is open to changes, based on our intentions to support the browsers listed here.

## Screenshots

| Screenshot from `/docs/self-hosted/latest` |
|-|
| <img width="766" alt="Screenshot 2022-08-23 at 6 39 07 PM" src="https://user-images.githubusercontent.com/120486/186201985-a2af4615-09c0-4214-aabb-0bcfac8dd905.png"> |


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2617"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

