### PR TITLE
Hide mobile menu button on desktop

### DIFF
--- a/src/lib/components/main-nav/mobile-menu/toggle.svelte
+++ b/src/lib/components/main-nav/mobile-menu/toggle.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { showHideOverflowY } from "$lib/utils/helpers";
+  import { showHideOverflowY, useMediaQuery } from "$lib/utils/helpers";
 
   import menuState from "./state";
+
+  $: shouldHide = useMediaQuery("(min-width: 1190px)");
 
   const handleToggle = () => {
     $menuState = !$menuState;
@@ -54,7 +56,14 @@
   }
 </style>
 
-<button on:click={handleToggle} aria-label="Show / hide nav items" class="py-3">
+<button
+  on:click={handleToggle}
+  aria-label="Show / hide nav items"
+  class="py-3"
+  hidden={$shouldHide}
+  aria-hidden={$shouldHide}
+  tabindex={$shouldHide ? -1 : 0}
+>
   <div
     class="flex flex-col items-center justify-center h-6 w-12 rounded-xl transition-all duration-200 {$menuState
       ? 'bg-sand-dark dark:bg-light-black'

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { readable } from "svelte/store";
+
 export const isEurope = () => {
   const offset = new Date().getTimezoneOffset();
   return offset <= 0 && offset >= -180;
@@ -48,4 +50,19 @@ export const sanitizeSelfHosted = (testString: string) => {
   return /self-hosted\/\d\.\d\.\d/.test(testString)
     ? testString.replace(/\d\.\d\.\d/, "latest")
     : testString;
+};
+
+export const useMediaQuery = (mediaQueryString: string) => {
+  const matches = readable<boolean>(null, (set) => {
+    if (typeof globalThis["window"] === "undefined") return;
+
+    const match = window.matchMedia(mediaQueryString);
+    set(match.matches);
+    const element = (event: MediaQueryListEvent) => set(event.matches);
+    match.addEventListener("change", element);
+    return () => {
+      match.removeEventListener("change", element);
+    };
+  });
+  return matches;
 };


### PR DESCRIPTION
## Description
Make it so you cannot focus on the button that triggers the mobile menu when on desktop (or larger viewports)

## Related Issue(s)
n/a

## How to test
Tab through the menu and observe you cannot focus on this "invisible" component.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```



<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2658"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

