### PR TITLE
`VS Code Web` -> `VS Code Browser`

### DIFF
--- a/gitpod/docs/ides-and-editors/vscode-extensions.md
+++ b/gitpod/docs/ides-and-editors/vscode-extensions.md
@@ -19,7 +19,7 @@ Still, you may wish to customize Gitpod, or to extend it with new features. You 
 
 To install a VS Code extension in Gitpod, simply go to the left vertical menu, and open the Extensions view. There you can search for an extension and install it with one click.
 
-For [VS Code Web](vscode-browser), we use the [Open VSX](https://open-vsx.org/) registry. If you can't find an extension you use in your local VS Code, please read the "[Where do I find extensions?](#where-do-i-find-extensions)" section below.
+For [VS Code Browser](vscode-browser), we use the [Open VSX](https://open-vsx.org/) registry. If you can't find an extension you use in your local VS Code, please read the "[Where do I find extensions?](#where-do-i-find-extensions)" section below.
 
 If the extension is helpful to anyone who works on the project, you can add it to the `.gitpod.yml` configuration file so that it gets installed for anyone who works on the project. To do that:
 
@@ -60,7 +60,7 @@ You can view all pre-installed extensions by navigating to VS Code's Extensions 
 
 ## Where do I find extensions?
 
-If you cannot find an extension by searching in Gitpod using [VS Code Web](vscode-browser), it probably means that the extension hasn't been added to the [Open VSX](https://open-vsx.org/) registry yet.
+If you cannot find an extension by searching in Gitpod using [VS Code Browser](vscode-browser), it probably means that the extension hasn't been added to the [Open VSX](https://open-vsx.org/) registry yet.
 
 In that case, please reach out to the extension author and politely ask them to publish their extension to the vendor-neutral, open source Open VSX registry. The "[How to Publish an Extension](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions)" docs provide step-by-step instructions.
 

--- a/gitpod/docs/troubleshooting.md
+++ b/gitpod/docs/troubleshooting.md
@@ -11,7 +11,7 @@ title: Troubleshooting
 
 If you cannot find your issue here or in the documentation, please contact Gitpod via our [Support page](/support).
 
-## Gitpod logs in VS Code Web and Desktop
+## Gitpod logs in VS Code Browser and Desktop
 
 These logs contain information about the workspace, the session, and the Visual Studio Code environment. They are useful for diagnosing connection issues and other unexpected behavior.
 

--- a/src/lib/components/docs/ide-toggle.svelte
+++ b/src/lib/components/docs/ide-toggle.svelte
@@ -5,7 +5,7 @@
 
   export let items: comparisonItem[] = [
     {
-      mobileTitle: "VS Code Web",
+      mobileTitle: "VS Code Browser",
       title: "VS Code Browser",
       value: 1,
       slotName: "vscodebrowser",


### PR DESCRIPTION
## Description

Changes the remaining occurrences of `VS Code Web` to our standardized `VS Code Browser`. This is a part of changes implemented as part of the `Create a doc explaining our Notion and website nomenclature` RFC [[internal link](https://www.notion.so/gitpod/RFC-Create-a-doc-explaining-our-Notion-and-website-nomenclature-167c133945624f1e9d3747ed8beb157c)].

## Related Issue(s)
n/a

## How to test
Testing is not needed, just code review.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
This updates documentation.

<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2663"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2663"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

