### PR TITLE
Add AKS reference architecture

### DIFF
--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/cluster.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/cluster.md
@@ -615,4 +615,67 @@ aws iam delete-policy --policy-arn 'arn:aws:iam::12344:policy/gitpod_s3_access_p
 ```
 
 </div>
+
+<div slot="azure">
+
+TODO: latest Kubernetes version
+
+```bash
+AKS_VERSION=$(az aks get-versions \
+--location northeurope \
+--query "orchestrators[?contains(orchestratorVersion, '1.24.')].orchestratorVersion" \
+-o json | jq -r '.[-1]')
+```
+
+```bash
+K8S_NODE_VM_SIZE=${K8S_NODE_VM_SIZE:="Standard_D4_v3"}
+SERVICES_POOL="services"
+WORKSPACES_POOL="workspaces"
+
+az aks create \
+	--enable-cluster-autoscaler \
+	--enable-managed-identity \
+	--location "${LOCATION}" \
+	--kubernetes-version "${AKS_VERSION}" \
+	--min-count "1" \
+	--max-count "4" \
+	--max-pods "110" \
+	--name "${CLUSTER_NAME}" \
+	--node-osdisk-size "100" \
+	--node-vm-size "${K8S_NODE_VM_SIZE}" \
+	--nodepool-labels gitpod.io/workload_meta=true gitpod.io/workload_ide=true \
+	--nodepool-name "${SERVICES_POOL}" \
+	--resource-group "${RESOURCE_GROUP}" \
+	--no-ssh-key \
+	--vm-set-type "VirtualMachineScaleSets"
+```
+
+**NOTE**: Same VM size used for both workspaces and services; these need to be adjusted.
+
+```bash
+ az aks nodepool add \
+	--cluster-name "${CLUSTER_NAME}" \
+	--enable-cluster-autoscaler \
+	--kubernetes-version "${AKS_VERSION}" \
+	--labels gitpod.io/workload_workspace_services=true gitpod.io/workload_workspace_regular=true gitpod.io/workload_workspace_headless=true \
+	--min-count "1" \
+	--max-count "50" \
+	--max-pods "110" \
+	--name "${WORKSPACES_POOL}" \
+	--node-osdisk-size "512" \
+	--node-vm-size "${K8S_NODE_VM_SIZE}" \
+	--resource-group "${RESOURCE_GROUP}"
+```
+
+```bash
+az aks get-credentials \
+    --name "${CLUSTER_NAME}" \
+    --resource-group "${RESOURCE_GROUP}" \
+    --overwrite-existing
+```
+
+NOTE: image pull secrets? Needed? (https://github.com/gitpod-io/gitpod-microsoft-aks-guide/blob/main/setup.sh#L130)
+
+</div>
+
 </CloudPlatformToggle>

--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/networking.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/networking.md
@@ -202,6 +202,58 @@ helm upgrade \
 With Route53 created, you can now proceed to install cert-manager. Cert-manager is needed for Gitpod's internal networking even if you are managing DNS yourself.
 
 </div>
+
+<div slot="azure">
+
+**DNS Zone**
+
+```bash
+DOMAIN_NAME="azure.adrien.gitpod-self-hosted.com"
+az network dns zone create --name $DOMAIN_NAME --resource-group $RESOURCE_GROUP
+```
+
+**Authorize AKS cluster to control DNS records in the zone**
+
+```bash
+ZONE_ID=$(az network dns zone show --name "${DOMAIN}" --resource-group "${RESOURCE_GROUP}" --query "id" -o tsv)
+KUBELET_OBJECT_ID=$(az aks show --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" --query "identityProfile.kubeletidentity.objectId" -o tsv)
+KUBELET_CLIENT_ID=$(az aks show --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" --query "identityProfile.kubeletidentity.clientId" -o tsv)
+
+az role assignment create \
+    --assignee "${KUBELET_OBJECT_ID}" \
+    --role "DNS Zone Contributor" \
+    --scope "${ZONE_ID}"
+```
+
+> Note: this authorization authorizes both cert-manager and external-dns to manage records in the DNS zones.
+> This differs from AWS and GCP in that the other clouds require independent credentials to operate.
+
+**Install External-DNS**
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm upgrade \
+    --atomic \
+    --cleanup-on-fail \
+    --create-namespace \
+    --install \
+    --namespace external-dns \
+    --reset-values \
+    --set provider=azure \
+    --set azure.resourceGroup="${RESOURCE_GROUP}" \
+    --set azure.subscriptionId="${AZURE_SUBSCRIPTION_ID}" \
+    --set azure.tenantId="${AZURE_TENANT_ID}" \
+    --set azure.useManagedIdentityExtension=true \
+    --set azure.userAssignedIdentityID="${KUBELET_CLIENT_ID}" \
+    --set logFormat=json \
+    --wait \
+    external-dns \
+    bitnami/external-dns
+```
+
+</div>
+
 </CloudPlatformToggle>
 
 ### cert-manager
@@ -263,6 +315,25 @@ kubectl patch deployment cert-manager -n cert-manager -p \
 
 ```
 
+</div>
+
+<div slot="azure">
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm upgrade \
+    --atomic \
+    --cleanup-on-fail \
+    --create-namespace \
+    --install \
+    --namespace='cert-manager' \
+    --reset-values \
+    --set installCRDs=true \
+    --set 'extraArgs={--dns01-recursive-nameservers-only=true,--dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53}' \
+    --wait \
+    cert-manager \
+    jetstack/cert-manager
+```
 </div>
 </CloudPlatformToggle>
 
@@ -343,4 +414,30 @@ spec:
 ```
 
 </div>
+
+<div slot="azure">
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: gitpod-issuer
+spec:
+  acme:
+    email: $LETSENCRYPT_EMAIL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: issuer-account-key
+    solvers:
+      - dns01:
+          azureDNS:
+            subscriptionID: $AZURE_SUBSCRIPTION_ID
+            resourceGroupName: $RESOURCE_GROUP
+            hostedZoneName: $DOMAIN
+```
+
+```bash
+kubectl apply -f issuer.yaml
+```
+
 </CloudPlatformToggle>

--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
@@ -102,6 +102,10 @@ This guide uses the following tools:
 - [Azure CLI](...)
 - Helm
 
+```bash
+az aks install-cli
+```
+
 TODO: document resource group
 
 ```bash

--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
@@ -106,6 +106,12 @@ This guide uses the following tools:
 az aks install-cli
 ```
 
+TODO: describe required variables
+
+```
+export *VARIABLES
+```
+
 TODO: document resource group
 
 ```bash

--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/preparations.md
@@ -94,4 +94,20 @@ All commands that follow assume you have set an environment variable of `AWS_REG
 
 </div>
 
+<div slot="azure">
+
+TODO: enumerate credentials needed to create AKS resources.
+
+This guide uses the following tools:
+- [Azure CLI](...)
+- Helm
+
+TODO: document resource group
+
+```bash
+az group create --location $LOCATION --name gitpod
+```
+
+</div>
+
 </CloudPlatformToggle>


### PR DESCRIPTION
## Description

This pull request adds instructions to install Gitpod on Azure/AKS. Installation instructions are derived from the [gitpod-microsoft-azure-guide](https://github.com/gitpod-io/gitpod-microsoft-aks-guide).

## Related Issue(s)

<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Run through the guide instructions and make sure the setup steps and associated documentation are clear, and required steps are distinguished from general howtos.

Azure setup instructions are available in the [internal documentation](https://www.notion.so/gitpod/Authenticate-to-the-Azure-API-404d24dc576f415ca2db745e91f9b5d3)

## Release Notes

```release-note
[reference-architecture] Add Azure single-cluster guide
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
