### PR TITLE
Update compatibility matrix link

### DIFF
--- a/src/lib/contents/docs/menu.ts
+++ b/src/lib/contents/docs/menu.ts
@@ -126,7 +126,7 @@ export const MENU: MenuEntry[] = [
     ]),
   ]),
   M("References", "references", [
-    M("Compatibility Matrix", "references/product-compatibility-matrix?user"),
+    M("Compatibility Matrix", "references/product-compatibility-matrix"),
     M(".gitpod.yml", "references/gitpod-yml"),
     M("Command Line Interface", "command-line-interface"),
     // M("Custom Docker image", "references/gitpod-dockerfile"),


### PR DESCRIPTION
## Description

This will update the Compatibility Matrix link in the left sidebar so that the menu item remains active while visiting `/docs/references/product-compatibility-matrix`.

Cc @nisarhassan12 because of the [relevant diff](https://github.com/gitpod-io/website/blob/78a22c7425671cdb8e62eee18d0403d127d21717/src/lib/contents/docs/menu.ts#L129) below:

https://github.com/gitpod-io/website/blob/78a22c7425671cdb8e62eee18d0403d127d21717/src/lib/contents/docs/menu.ts#L129

Cc @lucasvaltl because the [relevant discussion](https://gitpod.slack.com/archives/C019K7PND1A/p1662382581749779) (internal).

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1366" alt="Screenshot 2022-09-05 at 4 10 19 PM (2)" src="https://user-images.githubusercontent.com/120486/188457574-db6d4e90-9a01-4549-a040-13751915c7d5.png"> | <img width="1366" alt="Screenshot 2022-09-05 at 4 10 13 PM (2)" src="https://user-images.githubusercontent.com/120486/188457462-1ec1ed09-8868-420f-8d5a-2c4f0f932c15.png"> |


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2689"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

