### PR TITLE
[RefArch] Update node sizes for GCP and AWS

### DIFF
--- a/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/cluster.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/_chunks/cluster.md
@@ -24,11 +24,11 @@ You need to assign the following labels to the node pools to enforce that the Gi
 
 The following table gives an overview of the node types for the different cloud providers that are used by this reference architecture.
 
-|                              | GCP              | AWS           |
-| ---------------------------- | ---------------- | ------------- |
-| Services Node Pool           | `n2d-standard-4` | `m6i.xlarge`  |
-| Regular Workspace Node Pool  | `n2d-standard-8` | `m6i.2xlarge` |
-| Headless Workspace Node Pool | `n2d-standard-8` | `m6i.2xlarge` |
+|                              | GCP               | AWS           |
+| ---------------------------- | ----------------- | ------------- |
+| Services Node Pool           | `n2d-standard-4`  | `m6i.xlarge`  |
+| Regular Workspace Node Pool  | `n2d-standard-16` | `m6i.4xlarge` |
+| Headless Workspace Node Pool | `n2d-standard-16` | `m6i.4xlarge` |
 
 <CloudPlatformToggle id="cloud-platform-toggle-cluster">
 
@@ -153,7 +153,7 @@ We are also creating a **node pool for the Gitpod regular workspaces**.
 |                   |                                                                                     |
 | ----------------- | ----------------------------------------------------------------------------------- |
 | Image Type        | `UBUNTU_CONTAINERD`                                                                 |
-| Machine Type      | `n2d-standard-8`                                                                    |
+| Machine Type      | `n2d-standard-16`                                                                   |
 | Enable            | Autoscaling,<br/>Autorepair,<br/>IP Alias,<br/>Network Policy                       |
 | Disable           | Autoupgrade<br/>`metadata=disable-legacy-endpoints=true`                            |
 | Create Subnetwork | `gitpod-${CLUSTER_NAME}`                                                            |
@@ -172,7 +172,7 @@ gcloud container node-pools \
     --disk-type="pd-ssd" \
     --disk-size="512GB" \
     --image-type="UBUNTU_CONTAINERD" \
-    --machine-type="n2d-standard-8" \
+    --machine-type="n2d-standard-16" \
     --num-nodes=1 \
     --no-enable-autoupgrade \
     --enable-autorepair \
@@ -191,7 +191,7 @@ We are also creating a **node pool for the Gitpod headless workspaces**.
 |                   |                                                                                     |
 | ----------------- | ----------------------------------------------------------------------------------- |
 | Image Type        | `UBUNTU_CONTAINERD`                                                                 |
-| Machine Type      | `n2d-standard-8`                                                                    |
+| Machine Type      | `n2d-standard-16`                                                                   |
 | Enable            | Autoscaling,<br/>Autorepair,<br/>IP Alias,<br/>Network Policy                       |
 | Disable           | Autoupgrade<br/>`metadata=disable-legacy-endpoints=true`                            |
 | Create Subnetwork | `gitpod-${CLUSTER_NAME}`                                                            |
@@ -210,7 +210,7 @@ gcloud container node-pools \
     --disk-type="pd-ssd" \
     --disk-size="512GB" \
     --image-type="UBUNTU_CONTAINERD" \
-    --machine-type="n2d-standard-8" \
+    --machine-type="n2d-standard-16" \
     --num-nodes=1 \
     --no-enable-autoupgrade \
     --enable-autorepair \
@@ -398,7 +398,7 @@ managedNodeGroups:
   - name: regular-workspaces
     amiFamily: Ubuntu2004
     spot: false
-    instanceTypes: ["m6i.2xlarge"]
+    instanceTypes: ["m6i.4xlarge"]
     desiredCapacity: 2
     minSize: 1
     maxSize: 50
@@ -439,7 +439,7 @@ managedNodeGroups:
   - name: headless-workspaces
     amiFamily: Ubuntu2004
     spot: false
-    instanceTypes: ["m6i.2xlarge"]
+    instanceTypes: ["m6i.4xlarge"]
     desiredCapacity: 2
     minSize: 1
     maxSize: 50

--- a/gitpod/docs/self-hosted/latest/reference-architecture/proof-of-value.md
+++ b/gitpod/docs/self-hosted/latest/reference-architecture/proof-of-value.md
@@ -47,7 +47,7 @@ The following table gives an overview of the node types for the different cloud 
 
 |                  | GCP               | AWS           |
 | ---------------- | ----------------- | ------------- |
-| Gitpod Node Pool | `n2d-standard-16` | `m6i.2xlarge` |
+| Gitpod Node Pool | `n2d-standard-16` | `m6i.4xlarge` |
 
 <CloudPlatformToggle id="cloud-platform-toggle-cluster">
 


### PR DESCRIPTION
## Description
The node types for the reference architecture are too small. As discussed with @kylos101 we should use the same size as we currently use for SaaS.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update node sizes for GCP and AWS
```


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2790"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

