### PR TITLE
2022.09 Self-Hosted Release - Changelog Entry

### DIFF
--- a/src/lib/contents/changelog/2022-08-26 copy.md
+++ b/src/lib/contents/changelog/2022-08-26 copy.md
@@ -1,0 +1,31 @@
+---
+title: September Self-Hosted Release
+excerpt: We've released a new version of Self-Hosted Gitpod 🎉.
+date: 2022-09-30
+image: 2022-09-30.jpg
+tag: self-hosted
+alt:
+---
+
+<script>
+  import Contributors from "$lib/components/changelog/contributors.svelte";
+  import Badge from "$lib/components/changelog/badge.svelte"
+</script>
+
+We've released a new version of Self-Hosted Gitpod. Update instructions can be found in our [update guide](https://www.gitpod.io/docs/configure/self-hosted/latest/updating). You can read more about how to install it in our [documentation](https://www.gitpod.io/docs/configure/self-hosted/latest). More details on this release can be found on [GitHub](https://github.com/gitpod-io/gitpod/releases).
+
+> **Note:** If you are on a paid [Self-Hosted plan](../self-hosted), this release will be promoted to your release channel in one week.
+
+For feedback, please raise an [issue](https://github.com/gitpod-io/gitpod/issues/new?assignees=&labels=bug&template=bug_report.yml) or [chat with us](https://www.gitpod.io/chat).
+
+<p><Contributors usernames="nandajavarma,MrSimonEmms,Pothulapati,corneliusludmann,adrienthebo,lucasvaltl" /></p>
+
+### Feature highlights
+
+### Breaking changes
+
+-
+
+### Fixes and improvements
+
+A full list of changes can be found in [the release notes on GitHub](https://github.com/gitpod-io/gitpod/releases).


### PR DESCRIPTION
## Description
Describes the 2022.09 release in terms of features and breaking changes.

## How to test
- Review contents

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```