### PR TITLE
Fix dinky typo `gerlimit` 🠮 `getrlimit`

### DIFF
--- a/gitpod/docs/references/gitpod-yml.md
+++ b/gitpod/docs/references/gitpod-yml.md
@@ -175,7 +175,7 @@ coreDump:
   hardLimit: <bytes>
 ```
 
-For more details, please see the [Linux man page for `gerlimit`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)
+For more details, please see the [Linux man page for `getrlimit`](https://man7.org/linux/man-pages/man2/getrlimit.2.html)
 
 ## `gitConfig`
 


### PR DESCRIPTION
## Description
Fix dinky typo `gerlimit` 🠮 `getrlimit`.

## How to test
1. Put on your reading glasses.
1. Scroll down to the line right _above_ the `gitConfig` section header.
1. Check that the line above now has the correct API name; confirm by clicking the link and seeing that the name as now written matches the Linux documentation.

## Release Notes
... too dinky to put in release notes IMO ...


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/2833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

