### PR TITLE
Fixed the browser bookmarklet code.

### DIFF
--- a/gitpod/docs/configure/user-settings/browser-bookmarklet.md
+++ b/gitpod/docs/configure/user-settings/browser-bookmarklet.md
@@ -30,15 +30,15 @@ javascript: (() => {
       n++
     ) {
       var o = t[n];
-      if (o.content.toLowerCase().includes("gitlab")) return !0;
-      if ("hostname" === o.name && o.content.includes("github")) return !0;
+      if (o.content.toLowerCase().includes("gitlab")) return !1;
+      if ("hostname" === o.name && o.content.includes("github")) return !1;
       if (
         "application-name" === o.name &&
         o.content.toLowerCase().includes("bitbucket")
       )
-        return !0;
+        return !1;
     }
-    return !1;
+    return !0;
   })() &&
     window.open(
       ("https://gitpod.io",


### PR DESCRIPTION
## Description
Fixed the return values to fix the bookmarklet logic for determining whether to open a page in gitpod or not.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
use the code snippet to create a new bookmark. 
1. Positive test: navigate to a github, gitlab, or bitbucket repo and click the bookmarklet
2. Negative test: navigate to a regular web page (a non github, gitlab, or bitbucket repo) and click the bookmarklet

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation

This PR is a fix to the current documentation.

<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->


<a href="https://gitpod-staging.com/#https://github.com/gitpod-io/website/pull/2893"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

