### PR TITLE
Add notifications settings docs

### DIFF
--- a/gitpod/docs/configure/index.md
+++ b/gitpod/docs/configure/index.md
@@ -39,6 +39,7 @@ Workspaces can be created on their own, or as part of a [Project](/docs/configur
 - [Browser Bookmarklet](/docs/configure/user-settings/browser-bookmarklet)
 - [Dotfiles](/docs/configure/user-settings/dotfiles)
 - [SSH](/docs/configure/user-settings/ssh)
+- [Notifications](/docs/configure/user-settings/notifications)
 
 ## Projects
 

--- a/gitpod/docs/configure/user-settings/index.md
+++ b/gitpod/docs/configure/user-settings/index.md
@@ -16,3 +16,4 @@ User settings allow you to customize your own personal Gitpod experience.
 - [Browser Bookmarklet](/docs/configure/user-settings/browser-bookmarklet)
 - [Dotfiles](/docs/configure/user-settings/dotfiles)
 - [SSH](/docs/configure/user-settings/ssh)
+- [Notifications](/docs/configure/user-settings/notifications)

--- a/gitpod/docs/configure/user-settings/notifications.md
+++ b/gitpod/docs/configure/user-settings/notifications.md
@@ -1,0 +1,20 @@
+---
+section: user-settings
+title: Email notifications
+---
+
+<script context="module">
+  export const prerender = true;
+</script>
+
+# Email notifications
+
+Email notifications are enabled by default.
+
+You can modify email notification settings for the following:
+
+1. **Onboarding guide** - In the first weeks after you sign up, we'll guide you through the product, so you can get the most out of it
+1. **Changelog** - Be the first to learn about new features and overall product improvements
+1. **Developer Experience & Product Tips** - Bring back joy and speed to your workflows
+
+> **NOTE:** Disabling email notifications does not disable all emails from Gitpod. You will still receive important emails regarding account management, billing, and admin settings.

--- a/src/lib/contents/docs/menu.ts
+++ b/src/lib/contents/docs/menu.ts
@@ -64,6 +64,7 @@ export const MENU: MenuEntry[] = [
     M("Browser bookmarklet", "configure/user-settings/browser-bookmarklet"),
     M("Dotfiles", "configure/user-settings/dotfiles", false, []),
     M("SSH", "configure/user-settings/ssh"),
+    M("Notifications", "configure/user-settings/notifications"),
   ]),
 
   M(


### PR DESCRIPTION
## Description

This will add some docs around notifications users get when signing up and options they have.

Some more context on this:
1. We’ve received complaints about excessive emails we’re sending to users.
2. An always disabled option in the dashboard does not make much sense, opened https://github.com/gitpod-io/gitpod/pull/14746 to change this.
3. Users should receive emails considered important as account notifications, regardless if there’s an option.
4. Buckets below (Onboarding guide, Changelog, Developer Experience & Product Tips) fail to meet user expectations as we use these checkboxes to send out additional emails. We should definitely make them more explicit or improve how we bundle our users in customer.io.

Cc @easyCZ because https://github.com/gitpod-io/gitpod/pull/14746#discussion_r1024053335
Cc @chrifro because of a [relevant discussion](https://www.notion.so/gitpod/Design-co-working-bfa5ea6a761c47719f36f314e74b6391#c5a007016d024669b2e0eed2ea250299) (internal)
Cc @securitymirco because of a [relevant RFC](https://www.notion.so/gitpod/3285592fe943407f84cf2188e5ac8209) (internal)
Cc @laushinka @jakobhero because https://github.com/gitpod-io/gitpod/pull/5142
Cc @Siddhant-K-code @loujaybee because https://github.com/gitpod-io/website/pull/2587
Cc @jldec because of a [relevant discussion](https://www.notion.so/gitpod/e45137a3f27344868ea25b2b7e4f41a2#d4758504168345228a05d29a153b4592) (internal)
Cc @MichaelAring @phimae because a [relevant RFC](https://www.notion.so/gitpod/862bb5cac40c4aa98336db990c38799f) (internal)

Feedback is welcome!