### PR TITLE
Align beneift emojis consistently

### DIFF
--- a/src/lib/components/careers/what-we-offer.svelte
+++ b/src/lib/components/careers/what-we-offer.svelte
@@ -9,7 +9,7 @@
       <div
         class="bg-card py-[0.625rem] flex items-center px-micro rounded-2xl dark:bg-light-black text-important"
       >
-        <span class="mr-macro">{emoji}</span>
+        <span class="mr-macro w-7 flex-shrink-0 text-center">{emoji}</span>
         {text}
       </div>
     {/each}


### PR DESCRIPTION
## Description

On most platforms, emojis don't have the same width, so their horizontal alignment varies from benefit card to benefit card. Therefore, this makes the horizontal alignment of the emoji decoration in each benefit consistent by using a constant width of 28px for all emoji containers and centering the emojis.

(I noticed this while browsing through `gitpod.io` and it bugged me enough to make a PR. lol)

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/28510368/210620081-411cbc01-e3d1-4e2c-ac93-cc4917213774.png) |  ![image](https://user-images.githubusercontent.com/28510368/210620171-2c95ec6f-3c33-484b-bec5-2f73d56c5418.png) |
| ![image](https://user-images.githubusercontent.com/28510368/210620252-488b888d-feea-42de-994a-f094f697f9ea.png) | ![image](https://user-images.githubusercontent.com/28510368/210620327-9ceeeac0-363b-4ed3-b49a-9719f13b622f.png) |

## Related Issue(s)

None.

## How to test

1. In the footer, click on **Careers**
2. Scroll to the **Benefits** section
3. See that all emojis are horizontally in-line per column of benefits

## Release Notes

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->

```release-note
NONE
```


<a href="https://gitpod.io/#https://github.com/gitpod-io/website/pull/3214"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

