### PR TITLE
Clarify maximum workspace session time

### DIFF
--- a/gitpod/docs/configure/workspaces/workspace-lifecycle.md
+++ b/gitpod/docs/configure/workspaces/workspace-lifecycle.md
@@ -68,7 +68,7 @@ Running workspaces will stop automatically after a period of inactivity.
 
 ### Workspace Inactivity
 
-By default, workspaces stop following 30 minutes without user input (e.g. keystrokes or terminal input commands). You can increase the workspace timeout up to a maximum of 24 hours.
+By default, workspaces stop following 30 minutes without user input (e.g. keystrokes or terminal input commands). You can increase the workspace timeout, but keep in mind that workspaces can't be in the running state for more than 36 hours.
 
 ### Editor Disconnect
 


### PR DESCRIPTION


## Description

Change Workspace Lifecycle documentation to make it clearer that a workspace instance can live for more than 36 hours independently of the timeout that is set.

## Related Issue(s)

N/A

## How to test

N/A

## Release Notes

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->

```release-note
NONE

```
