### PR TITLE
add redirect for testing

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -291,3 +291,4 @@ docs/configure/billing/team-plans /docs/configure/billing/org-plans
 /changelog/rss /changelog/rss.xml
 /changelog/introducing:-flexible-timeouts-🥳-! /changelog/flexible-workspace-timeouts
 /changelog/introducing:-flexible-timeouts-%F0%9F%A5%B3-! /changelog/flexible-workspace-timeouts
+/docs/dedicated/sso-setup-8f7696e0 https://gitpod.notion.site/Getting-Started-36a3bcd5d3b345fbb7e4ff6aa959aa82#2af5c965b92b48f98143be63d33a98ca

--- a/_redirects
+++ b/_redirects
@@ -291,4 +291,4 @@ docs/configure/billing/team-plans /docs/configure/billing/org-plans
 /changelog/rss /changelog/rss.xml
 /changelog/introducing:-flexible-timeouts-🥳-! /changelog/flexible-workspace-timeouts
 /changelog/introducing:-flexible-timeouts-%F0%9F%A5%B3-! /changelog/flexible-workspace-timeouts
-/docs/dedicated/sso-setup-8f7696e0 https://gitpod.notion.site/Getting-Started-36a3bcd5d3b345fbb7e4ff6aa959aa82#2af5c965b92b48f98143be63d33a98ca
+/docs/dedicated/sso-setup-8f7696e0 https://gitpod.notion.site/Getting-Started-8d53c2ff4c394652b99111fb87e67be2


### PR DESCRIPTION
## Description

Adds a redirect to a dedicated docs page for sso. For now, this is done for testing whether this works. 

## How to test

Open the preview, try to manually add a suffix the URL

## Release Notes

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->

```release-note
NONE
```
