### PR TITLE
add note on gp validate

### DIFF
--- a/src/content/docs/gitpod-dedicated/guides/use-private-ecr-repos-for-workspace-images.md
+++ b/src/content/docs/gitpod-dedicated/guides/use-private-ecr-repos-for-workspace-images.md
@@ -35,3 +35,5 @@ Take the following steps to use a private ECR repository as the source for works
     ```
 
 You can now reference images from this ECR repository in [`.gitpod.yml` files](/docs/references/gitpod-yml) by specifying it in the `image` field: `image: <aws-ecr-url-prefix>.amazonaws.com/<your-image-name:tag>`. Ensure the images adhere to the requirements described [here](/docs/configure/workspaces/workspace-image#custom-base-image).
+
+> ℹ️ **Note:** [gp-validate](/docs/configure/workspaces#validate-your-gitpod-configuration) uses a docker daemon when pulling images. As such, credentials for the respective ECR repository need to be present when using it.


### PR DESCRIPTION
## Description

Adds a short note that the behaviour for authentication when using gp-validate is different - you need to log in yourself. Not sure if this is worded well or in the right place - hence making this a draft PR to start the conversation.